### PR TITLE
feat(tmux): add tmux app with TPM and vim-tmux-navigator

### DIFF
--- a/apps/apps.go
+++ b/apps/apps.go
@@ -20,6 +20,7 @@ import (
 	"github.com/eleonorayaya/shizuku/apps/sketchybar"
 	"github.com/eleonorayaya/shizuku/apps/terminal"
 	"github.com/eleonorayaya/shizuku/apps/terraform"
+	"github.com/eleonorayaya/shizuku/apps/tmux"
 	"github.com/eleonorayaya/shizuku/apps/zellij"
 	"github.com/eleonorayaya/shizuku/internal/shizukuapp"
 )
@@ -44,6 +45,7 @@ func GetApps() []shizukuapp.App {
 		sfsymbols.New(),
 		terminal.New(),
 		terraform.New(),
+		tmux.New(),
 		desktoppr.New(),
 		claude.New(),
 	}

--- a/apps/kitty/contents/kitty.conf.tmpl
+++ b/apps/kitty/contents/kitty.conf.tmpl
@@ -35,6 +35,8 @@ shell_integration  enabled
 open_url_with  default
 mouse_map  ctrl+left press grabbed,ungrabbed mouse_handle_click link
 map cmd+k no_op
+map cmd+b send_text all \x1bb
+map cmd+p send_text all \x1bp
 
 include colors.conf
 

--- a/apps/nvim/contents/lua/plugins/neo-tree.lua
+++ b/apps/nvim/contents/lua/plugins/neo-tree.lua
@@ -152,6 +152,15 @@ return {
         mode = { "n", "t" },
         desc = "Toggle explorer tree",
       },
+      {
+        "<M-b>",
+        function()
+          vim.cmd("Neotree toggle")
+          vim.cmd("wincmd p")
+        end,
+        mode = { "n", "t" },
+        desc = "Toggle explorer tree",
+      },
     },
   },
 }

--- a/apps/nvim/contents/lua/plugins/snacks.lua
+++ b/apps/nvim/contents/lua/plugins/snacks.lua
@@ -283,6 +283,16 @@ return {
           desc = "Files",
         },
         {
+          "<M-p>",
+          function()
+            Snacks.picker.files({
+              hidden = true,
+              ignored = false,
+            })
+          end,
+          desc = "Files",
+        },
+        {
           "<leader>fj",
           function()
             Snacks.picker.jumps({ layout = "ivy" })

--- a/apps/nvim/contents/lua/plugins/vim-tmux-navigator.lua
+++ b/apps/nvim/contents/lua/plugins/vim-tmux-navigator.lua
@@ -1,0 +1,12 @@
+return {
+  {
+    "christoomey/vim-tmux-navigator",
+    event = "VeryLazy",
+    keys = {
+      { "<C-h>", "<cmd>TmuxNavigateLeft<cr>", desc = "Navigate left" },
+      { "<C-j>", "<cmd>TmuxNavigateDown<cr>", desc = "Navigate down" },
+      { "<C-k>", "<cmd>TmuxNavigateUp<cr>", desc = "Navigate up" },
+      { "<C-l>", "<cmd>TmuxNavigateRight<cr>", desc = "Navigate right" },
+    },
+  },
+}

--- a/apps/tmux/contents/tmux.conf.tmpl
+++ b/apps/tmux/contents/tmux.conf.tmpl
@@ -57,7 +57,7 @@ bind r source-file ~/.config/tmux/tmux.conf \; display "Config reloaded"
 # plugins
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'christoomey/vim-tmux-navigator'
-set -g @plugin '/Users/eleonora/dev/utena/.worktrees/utena-tmux-ui/plugins/utena-tmux'
+set -g @plugin 'eleonorayaya/utena/plugins/utena-tmux'
 
 # TPM (keep at bottom)
 run '~/.config/tmux/plugins/tpm/tpm'

--- a/apps/tmux/contents/tmux.conf.tmpl
+++ b/apps/tmux/contents/tmux.conf.tmpl
@@ -1,0 +1,63 @@
+set -g default-terminal "tmux-256color"
+set -ag terminal-overrides ",xterm-256color:RGB"
+set -s extended-keys on
+set -as terminal-features 'xterm-256color:extkeys'
+bind-key -n S-Enter send-keys Escape "[13;2u"
+
+set -g mouse on
+set -g history-limit 10000
+set -g base-index 1
+setw -g pane-base-index 1
+set -g renumber-windows on
+set -g set-clipboard on
+
+set -g status-keys vi
+setw -g mode-keys vi
+
+set -sg escape-time 0
+set -g focus-events on
+
+# status bar
+set -g status-position bottom
+set -g status-style "bg={{.Surface}},fg={{.TextOnSurface}}"
+set -g status-left "#[bg={{.Primary}},fg={{.TextOnPrimary}},bold] #S #[default] "
+set -g status-left-length 30
+set -g status-right "#[fg={{.TextOnSurfaceMuted}}]%H:%M #[bg={{.SurfaceVariant}},fg={{.TextOnSurfaceVariant}}] #h "
+set -g status-right-length 50
+
+# window status
+setw -g window-status-format "#[fg={{.TextOnSurfaceMuted}}] #I:#W "
+setw -g window-status-current-format "#[bg={{.SurfaceHighlight}},fg={{.Primary}},bold] #I:#W "
+setw -g window-status-separator ""
+
+# pane borders
+set -g pane-border-style "fg={{.SurfaceBorder}}"
+set -g pane-active-border-style "fg={{.Primary}}"
+
+# message style
+set -g message-style "bg={{.SurfaceVariant}},fg={{.TextOnSurface}}"
+
+# window navigation
+unbind n
+unbind p
+bind h previous-window
+bind l next-window
+
+# pane splitting
+bind v split-window -h -c "#{pane_current_path}"
+bind s split-window -v -c "#{pane_current_path}"
+
+# new window in current path
+unbind c
+bind n new-window -c "#{pane_current_path}"
+
+# reload config
+bind r source-file ~/.config/tmux/tmux.conf \; display "Config reloaded"
+
+# plugins
+set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'christoomey/vim-tmux-navigator'
+set -g @plugin '/Users/eleonora/dev/utena/.worktrees/utena-tmux-ui/plugins/utena-tmux'
+
+# TPM (keep at bottom)
+run '~/.config/tmux/plugins/tpm/tpm'

--- a/apps/tmux/tmux.go
+++ b/apps/tmux/tmux.go
@@ -1,0 +1,101 @@
+package tmux
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+
+	"github.com/eleonorayaya/shizuku/internal/shizukuapp"
+	"github.com/eleonorayaya/shizuku/internal/shizukuconfig"
+	"github.com/eleonorayaya/shizuku/internal/util"
+)
+
+const tpmPath = "~/.config/tmux/plugins/tpm"
+
+type App struct{}
+
+func New() *App {
+	return &App{}
+}
+
+func (a *App) Name() string {
+	return "tmux"
+}
+
+func (a *App) Enabled(config *shizukuconfig.Config) bool {
+	return config.GetAppConfigBool(a.Name(), "enabled", true)
+}
+
+func (a *App) Install(config *shizukuconfig.Config) error {
+	if err := util.InstallBrewPackage("tmux", false); err != nil {
+		return fmt.Errorf("failed to install tmux: %w", err)
+	}
+
+	if err := ensureTPM(); err != nil {
+		return fmt.Errorf("failed to ensure TPM: %w", err)
+	}
+
+	return nil
+}
+
+func (a *App) Generate(outDir string, config *shizukuconfig.Config) (*shizukuapp.GenerateResult, error) {
+	colors := config.Styles.Theme.Colors
+	data := map[string]any{
+		"Surface":              colors.Surface,
+		"SurfaceVariant":       colors.SurfaceVariant,
+		"SurfaceHighlight":     colors.SurfaceHighlight,
+		"SurfaceBorder":        colors.SurfaceBorder,
+		"TextOnSurface":        colors.TextOnSurface,
+		"TextOnSurfaceVariant": colors.TextOnSurfaceVariant,
+		"TextOnSurfaceMuted":   colors.TextOnSurfaceMuted,
+		"Primary":              colors.Primary,
+		"TextOnPrimary":        colors.TextOnPrimary,
+	}
+
+	fileMap, err := shizukuapp.GenerateAppFiles("tmux", data, outDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate app files: %w", err)
+	}
+
+	return &shizukuapp.GenerateResult{
+		FileMap: fileMap,
+		DestDir: "~/.config/tmux/",
+	}, nil
+}
+
+func (a *App) Sync(outDir string, config *shizukuconfig.Config) error {
+	result, err := a.Generate(outDir, config)
+	if err != nil {
+		return err
+	}
+
+	if err := shizukuapp.SyncAppFiles(result.FileMap, result.DestDir); err != nil {
+		return fmt.Errorf("failed to sync app files: %w", err)
+	}
+
+	return nil
+}
+
+func ensureTPM() error {
+	expandedPath, err := util.NormalizeFilePath(tpmPath)
+	if err != nil {
+		return fmt.Errorf("failed to expand TPM path: %w", err)
+	}
+
+	if _, err := os.Stat(expandedPath); err == nil {
+		slog.Debug("TPM already installed, skipping")
+		return nil
+	}
+
+	slog.Debug("cloning TPM")
+
+	cmd := exec.Command("git", "clone", "https://github.com/tmux-plugins/tpm", expandedPath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to clone TPM: %w\nOutput: %s", err, string(output))
+	}
+
+	slog.Debug("TPM installed successfully")
+	return nil
+}


### PR DESCRIPTION
## Summary
- Add tmux as a shizuku-managed app with themed status bar, TPM plugin manager, and vim-tmux-navigator
- Configure Kitty to forward Cmd+b/Cmd+p through tmux via escape sequences, with Meta-key fallback mappings in neovim (neo-tree, snacks)
- Enable Shift+Enter passthrough in tmux for Claude Code compatibility

## Test plan
- [ ] `task build` succeeds
- [ ] `task run -- diff` shows tmux.conf with resolved theme colors
- [ ] `task run -- sync` syncs tmux.conf to `~/.config/tmux/` and clones TPM
- [ ] Cmd+b (neo-tree) and Cmd+p (file picker) work in neovim inside tmux
- [ ] Shift+Enter works in Claude Code inside tmux
- [ ] `prefix + h/l` navigate windows left/right
- [ ] vim-tmux-navigator Ctrl+h/j/k/l navigates between tmux panes and neovim splits

🤖 Generated with [Claude Code](https://claude.com/claude-code)