### PR TITLE
feat(glow): add glow app with monade theme

### DIFF
--- a/apps/apps.go
+++ b/apps/apps.go
@@ -7,6 +7,7 @@ import (
 	"github.com/eleonorayaya/shizuku/apps/desktoppr"
 	"github.com/eleonorayaya/shizuku/apps/fastfetch"
 	"github.com/eleonorayaya/shizuku/apps/git"
+	"github.com/eleonorayaya/shizuku/apps/glow"
 	"github.com/eleonorayaya/shizuku/apps/golang"
 	"github.com/eleonorayaya/shizuku/apps/jankyborders"
 	"github.com/eleonorayaya/shizuku/apps/kitty"
@@ -48,5 +49,6 @@ func GetApps() []shizukuapp.App {
 		tmux.New(),
 		desktoppr.New(),
 		claude.New(),
+		glow.New(),
 	}
 }

--- a/apps/glow/contents/glow.yml.tmpl
+++ b/apps/glow/contents/glow.yml.tmpl
@@ -1,0 +1,4 @@
+style: "{{ .HomeDir }}/Library/Preferences/glow/monade.json"
+mouse: true
+pager: false
+width: 80

--- a/apps/glow/contents/glow.yml.tmpl
+++ b/apps/glow/contents/glow.yml.tmpl
@@ -1,4 +1,5 @@
 style: "{{ .HomeDir }}/Library/Preferences/glow/monade.json"
 mouse: true
 pager: false
+tui: true
 width: 80

--- a/apps/glow/contents/monade.json.tmpl
+++ b/apps/glow/contents/monade.json.tmpl
@@ -1,0 +1,129 @@
+{
+  "document": {
+    "block_prefix": "\n",
+    "block_suffix": "\n",
+    "color": "{{ .Styles.Theme.Colors.TextOnSurface }}"
+  },
+  "block_quote": {
+    "indent": 1,
+    "indent_token": "│ ",
+    "color": "{{ .Styles.Theme.Colors.TextOnSurfaceMuted }}",
+    "prefix": " ",
+    "style_primitive": {
+      "color": "{{ .Styles.Theme.Colors.AccentLavender }}",
+      "italic": true
+    }
+  },
+  "paragraph": {
+    "block_suffix": "\n"
+  },
+  "list": {
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "{{ .Styles.Theme.Colors.Primary }}",
+    "bold": true
+  },
+  "h1": {
+    "prefix": "# ",
+    "color": "{{ .Styles.Theme.Colors.Primary }}",
+    "bold": true,
+    "upper": true
+  },
+  "h2": {
+    "prefix": "## ",
+    "color": "{{ .Styles.Theme.Colors.Tertiary }}",
+    "bold": true
+  },
+  "h3": {
+    "prefix": "### ",
+    "color": "{{ .Styles.Theme.Colors.AccentPeach }}",
+    "bold": true
+  },
+  "h4": {
+    "prefix": "#### ",
+    "color": "{{ .Styles.Theme.Colors.AccentGold }}",
+    "bold": true
+  },
+  "h5": {
+    "prefix": "##### ",
+    "color": "{{ .Styles.Theme.Colors.AccentMint }}",
+    "bold": true
+  },
+  "h6": {
+    "prefix": "###### ",
+    "color": "{{ .Styles.Theme.Colors.AccentBlue }}",
+    "bold": true
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "color": "{{ .Styles.Theme.Colors.AccentSalmon }}",
+    "italic": true
+  },
+  "strong": {
+    "color": "{{ .Styles.Theme.Colors.TextOnSurfaceEmphasis }}",
+    "bold": true
+  },
+  "hr": {
+    "color": "{{ .Styles.Theme.Colors.SurfaceBorder }}",
+    "format": "\n--------\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". "
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "color": "{{ .Styles.Theme.Colors.Link }}",
+    "underline": true
+  },
+  "link_text": {
+    "color": "{{ .Styles.Theme.Colors.Link }}",
+    "bold": true
+  },
+  "image": {
+    "color": "{{ .Styles.Theme.Colors.Link }}",
+    "underline": true
+  },
+  "image_text": {
+    "color": "{{ .Styles.Theme.Colors.Link }}",
+    "format": "Image: {{`{{.text}}`}} →"
+  },
+  "code": {
+    "color": "{{ .Styles.Theme.Colors.AccentPurple }}"
+  },
+  "code_block": {
+    "color": "{{ .Styles.Theme.Colors.TextOnSurface }}",
+    "background_color": "{{ .Styles.Theme.Colors.SurfaceVariant }}",
+    "margin": 2,
+    "chroma": {
+      "theme": "solarized-light"
+    }
+  },
+  "table": {
+    "center_separator": "┼",
+    "column_separator": "│",
+    "row_separator": "─",
+    "color": "{{ .Styles.Theme.Colors.TextOnSurfaceVariant }}"
+  },
+  "definition_list": {},
+  "definition_term": {
+    "block_suffix": "\n",
+    "color": "{{ .Styles.Theme.Colors.Primary }}",
+    "bold": true
+  },
+  "definition_description": {
+    "block_prefix": "\n"
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/apps/glow/glow.go
+++ b/apps/glow/glow.go
@@ -1,0 +1,75 @@
+package glow
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/eleonorayaya/shizuku/internal/shizukuapp"
+	"github.com/eleonorayaya/shizuku/internal/shizukuconfig"
+	"github.com/eleonorayaya/shizuku/internal/util"
+)
+
+type App struct{}
+
+func New() *App {
+	return &App{}
+}
+
+func (a *App) Name() string {
+	return "glow"
+}
+
+func (a *App) Enabled(config *shizukuconfig.Config) bool {
+	return config.GetAppConfigBool(a.Name(), "enabled", true)
+}
+
+func (a *App) Install(config *shizukuconfig.Config) error {
+	if err := util.InstallBrewPackage("glow", false); err != nil {
+		return fmt.Errorf("failed to install glow: %w", err)
+	}
+
+	return nil
+}
+
+func (a *App) Generate(outDir string, config *shizukuconfig.Config) (*shizukuapp.GenerateResult, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	data := map[string]any{
+		"Styles":  config.Styles,
+		"HomeDir": homeDir,
+	}
+
+	fileMap, err := shizukuapp.GenerateAppFiles("glow", data, outDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate app files: %w", err)
+	}
+
+	return &shizukuapp.GenerateResult{
+		FileMap: fileMap,
+		DestDir: "~/Library/Preferences/glow/",
+	}, nil
+}
+
+func (a *App) Sync(outDir string, config *shizukuconfig.Config) error {
+	result, err := a.Generate(outDir, config)
+	if err != nil {
+		return err
+	}
+
+	if err := shizukuapp.SyncAppFiles(result.FileMap, result.DestDir); err != nil {
+		return fmt.Errorf("failed to sync app files: %w", err)
+	}
+
+	return nil
+}
+
+func (a *App) Env() (*shizukuapp.EnvSetup, error) {
+	return &shizukuapp.EnvSetup{
+		Aliases: []shizukuapp.Alias{
+			{Name: "md", Command: "glow"},
+		},
+	}, nil
+}

--- a/apps/kitty/contents/kitty.conf.tmpl
+++ b/apps/kitty/contents/kitty.conf.tmpl
@@ -1,6 +1,6 @@
 scrollback_lines  10000
 enable_audio_bell  false
-background_opacity .{{.Styles.WindowOpacity}}
+background_opacity {{.Styles.WindowOpacity}}
 background_blur  48
 window_padding_width 4 8 0 8
 hide_window_decorations  titlebar-only


### PR DESCRIPTION
## Summary

- Adds [glow](https://github.com/charmbracelet/glow) as a new shizuku app (Installer, FileGenerator, FileSyncer, EnvProvider)
- Custom glamour theme using monade palette colors for headings, links, code blocks, tables, and other markdown elements
- Syncs config and theme to `~/Library/Preferences/glow/` (glow's macOS config path)
- Adds `md` shell alias for quick markdown rendering
- Fixes kitty `background_opacity` value formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)