### PR TITLE
fix: shift+enter in tmux and kitty opacity

### DIFF
--- a/apps/claude/contents/keybindings.json
+++ b/apps/claude/contents/keybindings.json
@@ -19,6 +19,8 @@
         "meta+p": "chat:modelPicker",
         "meta+t": "chat:thinkingToggle",
         "enter": "chat:submit",
+        "alt+enter": "chat:newline",
+        "ctrl+shift+j": "chat:newline",
         "up": "history:previous",
         "down": "history:next",
         "ctrl+_": "chat:undo",

--- a/apps/claude/contents/keybindings.json
+++ b/apps/claude/contents/keybindings.json
@@ -19,7 +19,6 @@
         "meta+p": "chat:modelPicker",
         "meta+t": "chat:thinkingToggle",
         "enter": "chat:submit",
-        "alt+enter": "chat:newline",
         "ctrl+shift+j": "chat:newline",
         "up": "history:previous",
         "down": "history:next",

--- a/apps/kitty/contents/kitty.conf.tmpl
+++ b/apps/kitty/contents/kitty.conf.tmpl
@@ -1,6 +1,6 @@
 scrollback_lines  10000
 enable_audio_bell  false
-background_opacity {{.Styles.WindowOpacity}}
+background_opacity {{.BackgroundAlpha}}
 background_blur  48
 window_padding_width 4 8 0 8
 hide_window_decorations  titlebar-only

--- a/apps/kitty/contents/kitty.conf.tmpl
+++ b/apps/kitty/contents/kitty.conf.tmpl
@@ -33,6 +33,7 @@ shell_integration  enabled
 
 open_url_with  default
 mouse_map  ctrl+left press grabbed,ungrabbed mouse_handle_click link
+map shift+enter send_text all \x1b[74;5u
 map cmd+k no_op
 map cmd+b send_text all \x1bb
 map cmd+p send_text all \x1bp

--- a/apps/kitty/kitty.go
+++ b/apps/kitty/kitty.go
@@ -45,7 +45,8 @@ func (a *App) Install(config *shizukuconfig.Config) error {
 
 func (a *App) Generate(outDir string, config *shizukuconfig.Config) (*shizukuapp.GenerateResult, error) {
 	data := map[string]any{
-		"Styles": config.Styles,
+		"Styles":          config.Styles,
+		"BackgroundAlpha": float64(config.Styles.WindowOpacity) / 100.0,
 	}
 
 	fileMap, err := shizukuapp.GenerateAppFiles("kitty", data, outDir)

--- a/apps/tmux/contents/tmux.conf.tmpl
+++ b/apps/tmux/contents/tmux.conf.tmpl
@@ -1,8 +1,8 @@
 set -g default-terminal "tmux-256color"
-set -ag terminal-overrides ",xterm-256color:RGB"
-set -s extended-keys on
+set -ag terminal-overrides ",xterm-256color:RGB,xterm-kitty:RGB"
+set -s extended-keys always
 set -as terminal-features 'xterm-256color:extkeys'
-bind-key -n S-Enter send-keys Escape "[13;2u"
+set -as terminal-features 'xterm-kitty:extkeys'
 
 set -g mouse on
 set -g history-limit 10000


### PR DESCRIPTION
## Summary
- Fix Shift+Enter newline in Claude Code inside tmux by having kitty send a custom CSI u sequence mapped to `chat:newline` in Claude keybindings
- Improve tmux extended-keys config for xterm-kitty terminal
- Fix kitty background_opacity by converting WindowOpacity (0-100 int) to a 0.0-1.0 float in Go

## Test plan
- [ ] Verify Shift+Enter inserts newlines in Claude Code inside kitty+tmux
- [ ] Verify kitty background opacity works for values < 100 (e.g. 80 → 0.8)
- [ ] Verify opacity 100 still works (100 → 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)