### PR TITLE
feat(golang): install gopls, dynamic GOPATH, and language config

### DIFF
--- a/apps/golang/golang.go
+++ b/apps/golang/golang.go
@@ -2,6 +2,10 @@ package golang
 
 import (
 	"fmt"
+	"log/slog"
+	"os/exec"
+	"path"
+	"strings"
 
 	"github.com/eleonorayaya/shizuku/internal/shizukuapp"
 	"github.com/eleonorayaya/shizuku/internal/shizukuconfig"
@@ -19,7 +23,7 @@ func (a *App) Name() string {
 }
 
 func (a *App) Enabled(config *shizukuconfig.Config) bool {
-	return config.GetAppConfigBool(a.Name(), "enabled", false)
+	return config.GetLanguageEnabled(shizukuconfig.LanguageGo)
 }
 
 func (a *App) Install(config *shizukuconfig.Config) error {
@@ -27,13 +31,33 @@ func (a *App) Install(config *shizukuconfig.Config) error {
 		return fmt.Errorf("failed to install go-task: %w", err)
 	}
 
+	if !util.BinaryExists("gopls") {
+		slog.Debug("installing gopls via go install")
+
+		cmd := exec.Command("go", "install", "golang.org/x/tools/gopls@latest")
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("failed to install gopls: %w\nOutput: %s", err, string(output))
+		}
+
+		slog.Debug("gopls installed successfully")
+	}
+
 	return nil
 }
 
 func (a *App) Env() (*shizukuapp.EnvSetup, error) {
+	cmd := exec.Command("go", "env", "GOPATH")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get GOPATH: %w", err)
+	}
+
+	gopath := strings.TrimSpace(string(output))
+
 	return &shizukuapp.EnvSetup{
 		PathDirs: []shizukuapp.PathDir{
-			{Path: "$HOME/go/bin", Priority: 20},
+			{Path: path.Join(gopath, "bin"), Priority: 20},
 		},
 	}, nil
 }

--- a/internal/shizukuconfig/config.go
+++ b/internal/shizukuconfig/config.go
@@ -102,6 +102,14 @@ func (c *Config) GetAppConfigBool(appName string, configKey string, defaultValue
 	return boolValue
 }
 
+func (c *Config) GetLanguageEnabled(language Language) bool {
+	lang, ok := c.Languages[string(language)]
+	if !ok {
+		return false
+	}
+	return lang.Enabled
+}
+
 func (c *Config) save(configPath string) error {
 	yamlData, err := yaml.Marshal(c)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Install `gopls` via `go install` in the golang app's `Install` method when the binary isn't found
- Dynamically fetch `GOPATH` via `go env GOPATH` for PATH setup instead of hardcoding `$HOME/go/bin`
- Switch golang app to use language config (`languages.go.enabled`) instead of app config
- Add `GetLanguageEnabled` helper on `Config` for language-based app enablement

## Test plan
- [x] `task build` passes
- [x] `task test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)