### PR TITLE
feat(git): add global gitignore support

### DIFF
--- a/apps/git/contents/.gitignore_global
+++ b/apps/git/contents/.gitignore_global
@@ -1,0 +1,1 @@
+.worktrees/

--- a/apps/git/git.go
+++ b/apps/git/git.go
@@ -1,6 +1,9 @@
 package git
 
 import (
+	"fmt"
+	"os/exec"
+
 	"github.com/eleonorayaya/shizuku/internal/shizukuapp"
 	"github.com/eleonorayaya/shizuku/internal/shizukuconfig"
 )
@@ -21,6 +24,36 @@ func (a *App) Name() string {
 
 func (a *App) Enabled(config *shizukuconfig.Config) bool {
 	return config.GetAppConfigBool(a.Name(), "enabled", true)
+}
+
+func (a *App) Generate(outDir string, config *shizukuconfig.Config) (*shizukuapp.GenerateResult, error) {
+	fileMap, err := shizukuapp.GenerateAppFiles("git", nil, outDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate app files: %w", err)
+	}
+
+	return &shizukuapp.GenerateResult{
+		FileMap: fileMap,
+		DestDir: "~/",
+	}, nil
+}
+
+func (a *App) Sync(outDir string, config *shizukuconfig.Config) error {
+	result, err := a.Generate(outDir, config)
+	if err != nil {
+		return err
+	}
+
+	if err := shizukuapp.SyncAppFiles(result.FileMap, result.DestDir); err != nil {
+		return fmt.Errorf("failed to sync app files: %w", err)
+	}
+
+	cmd := exec.Command("git", "config", "--global", "core.excludesfile", "~/.gitignore_global")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to set global excludesfile: %w\nOutput: %s", err, string(output))
+	}
+
+	return nil
 }
 
 func (a *App) Env() (*shizukuapp.EnvSetup, error) {


### PR DESCRIPTION
## Summary
- Add `Generate()` and `Sync()` methods to the git app to manage `~/.gitignore_global`
- Create global gitignore file with `.worktrees/` ignore pattern
- Register the gitignore with git via `git config --global core.excludesfile` on sync

## Test plan
- [x] `task build` compiles successfully
- [x] `task run -- diff` shows `.gitignore_global` in diff output
- [x] `task run -- sync` creates `~/.gitignore_global` and sets `core.excludesfile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)