### PR TITLE
feat: terminal window styles and config defaults

### DIFF
--- a/apps/kitty/contents/kitty.conf.tmpl
+++ b/apps/kitty/contents/kitty.conf.tmpl
@@ -2,7 +2,7 @@ scrollback_lines  10000
 enable_audio_bell  false
 background_opacity {{.BackgroundAlpha}}
 background_blur  48
-window_padding_width 4 8 0 8
+window_padding_width 0
 hide_window_decorations  titlebar-only
 
 allow_remote_control  true

--- a/apps/tmux/contents/tmux.conf.tmpl
+++ b/apps/tmux/contents/tmux.conf.tmpl
@@ -31,8 +31,12 @@ setw -g window-status-current-format "#[bg={{.SurfaceHighlight}},fg={{.Primary}}
 setw -g window-status-separator ""
 
 # pane borders
-set -g pane-border-style "fg={{.SurfaceBorder}}"
-set -g pane-active-border-style "fg={{.Primary}}"
+set -g pane-border-style "fg={{.Surface}}"
+set -g pane-active-border-style "fg={{.SurfaceVariant}}"
+
+# dim inactive panes
+set -g window-style "bg=terminal"
+set -g window-active-style "bg={{.SurfaceVariant}}"
 
 # message style
 set -g message-style "bg={{.SurfaceVariant}},fg={{.TextOnSurface}}"

--- a/internal/shizukuconfig/config_test.go
+++ b/internal/shizukuconfig/config_test.go
@@ -141,8 +141,8 @@ languages:
 		defaults := newConfig()
 		config.mergeWithDefaults(defaults)
 
-		if config.Styles.WindowOpacity != 100 {
-			t.Errorf("Expected default windowOpacity 100, got %d", config.Styles.WindowOpacity)
+		if config.Styles.WindowOpacity != defaultWindowOpacity {
+			t.Errorf("Expected default windowOpacity %d, got %d", defaultWindowOpacity, config.Styles.WindowOpacity)
 		}
 	})
 
@@ -216,16 +216,9 @@ func TestConfigValidate(t *testing.T) {
 	})
 
 	t.Run("rejects invalid language", func(t *testing.T) {
-		theme, _ := loadThemeFromRegistry("monade")
-		config := &Config{
-			Styles: Styles{
-				ThemeName:     "monade",
-				WindowOpacity: 100,
-				Theme:         theme,
-			},
-			Languages: LanguageConfigs{
-				"invalid-lang": {Enabled: true},
-			},
+		config := newConfig()
+		config.Languages = LanguageConfigs{
+			"invalid-lang": {Enabled: true},
 		}
 
 		if err := config.validate(); err == nil {

--- a/internal/shizukuconfig/merge_test.go
+++ b/internal/shizukuconfig/merge_test.go
@@ -150,22 +150,15 @@ func TestMergeStringAnyMap(t *testing.T) {
 }
 
 func TestConfigMergeWithDefaults(t *testing.T) {
+	defaults := newConfig()
+
 	t.Run("preserves existing theme", func(t *testing.T) {
-		customTheme, _ := loadThemeFromRegistry("monade")
-		defaultTheme, _ := loadThemeFromRegistry("monade")
+		customTheme, _ := loadThemeFromRegistry(defaultThemeName)
 		existing := &Config{
 			Styles: Styles{
 				ThemeName:     "custom-theme",
 				WindowOpacity: 85,
 				Theme:         customTheme,
-			},
-			Languages: make(LanguageConfigs),
-		}
-		defaults := &Config{
-			Styles: Styles{
-				ThemeName:     "monade",
-				WindowOpacity: 100,
-				Theme:         defaultTheme,
 			},
 			Languages: make(LanguageConfigs),
 		}
@@ -181,7 +174,6 @@ func TestConfigMergeWithDefaults(t *testing.T) {
 	})
 
 	t.Run("uses default theme when empty", func(t *testing.T) {
-		defaultTheme, _ := loadThemeFromRegistry("monade")
 		existing := &Config{
 			Styles: Styles{
 				ThemeName:     "",
@@ -189,19 +181,11 @@ func TestConfigMergeWithDefaults(t *testing.T) {
 			},
 			Languages: make(LanguageConfigs),
 		}
-		defaults := &Config{
-			Styles: Styles{
-				ThemeName:     "monade",
-				WindowOpacity: 100,
-				Theme:         defaultTheme,
-			},
-			Languages: make(LanguageConfigs),
-		}
 
 		existing.mergeWithDefaults(defaults)
 
-		if existing.Styles.ThemeName != "monade" {
-			t.Error("Expected default theme when existing is empty")
+		if existing.Styles.ThemeName != defaultThemeName {
+			t.Errorf("Expected default theme %q, got %q", defaultThemeName, existing.Styles.ThemeName)
 		}
 		if existing.Styles.WindowOpacity != 85 {
 			t.Error("Expected existing windowOpacity to be preserved")
@@ -221,12 +205,10 @@ languages:
 			t.Fatalf("Failed to unmarshal YAML: %v", err)
 		}
 
-		defaults := newConfig()
-
 		existing.mergeWithDefaults(defaults)
 
-		if existing.Styles.WindowOpacity != 100 {
-			t.Errorf("Expected windowOpacity to be added from defaults (100), got %d", existing.Styles.WindowOpacity)
+		if existing.Styles.WindowOpacity != defaultWindowOpacity {
+			t.Errorf("Expected default windowOpacity %d, got %d", defaultWindowOpacity, existing.Styles.WindowOpacity)
 		}
 		if !existing.Languages["rust"].Enabled {
 			t.Error("Expected Rust to remain enabled from existing config")
@@ -234,25 +216,10 @@ languages:
 	})
 
 	t.Run("merges languages", func(t *testing.T) {
-		theme, _ := loadThemeFromRegistry("monade")
 		existing := &Config{
-			Styles: Styles{
-				ThemeName:     "monade",
-				WindowOpacity: 100,
-				Theme:         theme,
-			},
+			Styles:    createDefaultStyles(),
 			Languages: LanguageConfigs{
 				"rust": {Enabled: true, Config: make(map[string]any)},
-			},
-		}
-		defaults := &Config{
-			Styles: Styles{
-				ThemeName:     "monade",
-				WindowOpacity: 100,
-				Theme:         theme,
-			},
-			Languages: LanguageConfigs{
-				"rust": {Enabled: false, Config: make(map[string]any)},
 			},
 		}
 
@@ -264,13 +231,8 @@ languages:
 	})
 
 	t.Run("merges apps", func(t *testing.T) {
-		theme, _ := loadThemeFromRegistry("monade")
 		existing := &Config{
-			Styles: Styles{
-				ThemeName:     "monade",
-				WindowOpacity: 100,
-				Theme:         theme,
-			},
+			Styles:    createDefaultStyles(),
 			Languages: make(LanguageConfigs),
 			Apps: map[string]any{
 				"nvim": map[string]any{
@@ -278,12 +240,8 @@ languages:
 				},
 			},
 		}
-		defaults := &Config{
-			Styles: Styles{
-				ThemeName:     "monade",
-				WindowOpacity: 100,
-				Theme:         theme,
-			},
+		appDefaults := &Config{
+			Styles:    createDefaultStyles(),
 			Languages: make(LanguageConfigs),
 			Apps: map[string]any{
 				"nvim": map[string]any{
@@ -296,7 +254,7 @@ languages:
 			},
 		}
 
-		existing.mergeWithDefaults(defaults)
+		existing.mergeWithDefaults(appDefaults)
 
 		nvimConfig := existing.Apps["nvim"].(map[string]any)
 		if nvimConfig["enabled"] != true {
@@ -311,50 +269,23 @@ languages:
 	})
 
 	t.Run("handles nil languages", func(t *testing.T) {
-		theme, _ := loadThemeFromRegistry("monade")
 		existing := &Config{
-			Styles: Styles{
-				ThemeName:     "monade",
-				WindowOpacity: 100,
-				Theme:         theme,
-			},
+			Styles:    createDefaultStyles(),
 			Languages: nil,
-		}
-		defaults := &Config{
-			Styles: Styles{
-				ThemeName:     "monade",
-				WindowOpacity: 100,
-				Theme:         theme,
-			},
-			Languages: LanguageConfigs{
-				"rust": {Enabled: false, Config: make(map[string]any)},
-			},
 		}
 
 		existing.mergeWithDefaults(defaults)
 
-		if existing.Languages["rust"].Enabled != false {
-			t.Error("Expected default languages to be used when existing is nil")
+		for lang := range defaults.Languages {
+			if _, exists := existing.Languages[lang]; !exists {
+				t.Errorf("Expected default language %q to be added", lang)
+			}
 		}
 	})
 
 	t.Run("handles nil apps", func(t *testing.T) {
-		theme, _ := loadThemeFromRegistry("monade")
-		existing := &Config{
-			Styles: Styles{
-				ThemeName:     "monade",
-				WindowOpacity: 100,
-				Theme:         theme,
-			},
-			Languages: make(LanguageConfigs),
-			Apps:      nil,
-		}
-		defaults := &Config{
-			Styles: Styles{
-				ThemeName:     "monade",
-				WindowOpacity: 100,
-				Theme:         theme,
-			},
+		appDefaults := &Config{
+			Styles:    createDefaultStyles(),
 			Languages: make(LanguageConfigs),
 			Apps: map[string]any{
 				"nvim": map[string]any{
@@ -362,8 +293,13 @@ languages:
 				},
 			},
 		}
+		existing := &Config{
+			Styles:    createDefaultStyles(),
+			Languages: make(LanguageConfigs),
+			Apps:      nil,
+		}
 
-		existing.mergeWithDefaults(defaults)
+		existing.mergeWithDefaults(appDefaults)
 
 		if existing.Apps["nvim"] == nil {
 			t.Error("Expected default apps to be used when existing is nil")

--- a/internal/shizukuconfig/shizukuconfig.go
+++ b/internal/shizukuconfig/shizukuconfig.go
@@ -17,7 +17,14 @@ func LoadConfig() (*Config, error) {
 		return nil, fmt.Errorf("failed to normalize config path: %w", err)
 	}
 
-	return newConfigFromPath(configPath)
+	config, err := newConfigFromPath(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	config.mergeWithDefaults(newConfig())
+
+	return config, nil
 }
 
 func InitConfig() (bool, string, error) {

--- a/internal/shizukuconfig/shizukuconfig_test.go
+++ b/internal/shizukuconfig/shizukuconfig_test.go
@@ -74,6 +74,133 @@ func TestInitConfig(t *testing.T) {
 	})
 }
 
+func TestLoadConfigMergesDefaults(t *testing.T) {
+	defaults := newConfig()
+
+	t.Run("merges default windowOpacity when missing", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "shizuku.yml")
+		configContent := `
+styles:
+  theme: monade
+languages:
+  rust:
+    enabled: true
+`
+		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+			t.Fatalf("Failed to write test config: %v", err)
+		}
+
+		config, err := loadConfigFromPathWithDefaults(configPath)
+		if err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+
+		if config.Styles.WindowOpacity != defaultWindowOpacity {
+			t.Errorf("Expected default windowOpacity %d, got %d", defaultWindowOpacity, config.Styles.WindowOpacity)
+		}
+	})
+
+	t.Run("preserves explicit windowOpacity", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "shizuku.yml")
+		configContent := `
+styles:
+  theme: monade
+  windowOpacity: 90
+languages:
+  rust:
+    enabled: true
+`
+		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+			t.Fatalf("Failed to write test config: %v", err)
+		}
+
+		config, err := loadConfigFromPathWithDefaults(configPath)
+		if err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+
+		if config.Styles.WindowOpacity != 90 {
+			t.Errorf("Expected windowOpacity 90, got %d", config.Styles.WindowOpacity)
+		}
+	})
+
+	t.Run("merges missing languages from defaults", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "shizuku.yml")
+		configContent := `
+styles:
+  theme: monade
+languages:
+  rust:
+    enabled: true
+`
+		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+			t.Fatalf("Failed to write test config: %v", err)
+		}
+
+		config, err := loadConfigFromPathWithDefaults(configPath)
+		if err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+
+		if !config.Languages["rust"].Enabled {
+			t.Error("Expected rust to remain enabled")
+		}
+
+		for lang := range defaults.Languages {
+			if _, exists := config.Languages[lang]; !exists {
+				t.Errorf("Expected default language %q to be present after merge", lang)
+			}
+		}
+	})
+
+	t.Run("merges all defaults for minimal config", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "shizuku.yml")
+		configContent := `
+styles:
+  theme: monade
+`
+		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+			t.Fatalf("Failed to write test config: %v", err)
+		}
+
+		config, err := loadConfigFromPathWithDefaults(configPath)
+		if err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+
+		if config.Styles.WindowOpacity != defaultWindowOpacity {
+			t.Errorf("Expected default windowOpacity %d, got %d", defaultWindowOpacity, config.Styles.WindowOpacity)
+		}
+		if config.Styles.ThemeName != defaultThemeName {
+			t.Errorf("Expected theme %q, got %q", defaultThemeName, config.Styles.ThemeName)
+		}
+		if config.Styles.Theme == nil {
+			t.Error("Expected theme to be loaded")
+		}
+		for lang := range defaults.Languages {
+			if _, exists := config.Languages[lang]; !exists {
+				t.Errorf("Expected default language %q to be present", lang)
+			}
+		}
+	})
+}
+
+// loadConfigFromPathWithDefaults mirrors LoadConfig but accepts a path for testing.
+func loadConfigFromPathWithDefaults(configPath string) (*Config, error) {
+	config, err := newConfigFromPath(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	config.mergeWithDefaults(newConfig())
+
+	return config, nil
+}
+
 func initConfigAtPath(configPath string) (bool, string, error) {
 	if _, err := os.Stat(configPath); err == nil {
 		return false, configPath, nil

--- a/internal/shizukuconfig/styles.go
+++ b/internal/shizukuconfig/styles.go
@@ -32,7 +32,7 @@ func (s *Styles) UnmarshalYAML(node *yaml.Node) error {
 
 var (
 	defaultThemeName     = "monade"
-	defaultWindowOpacity = 85
+	defaultWindowOpacity = 65
 )
 
 func createDefaultStyles() Styles {

--- a/internal/shizukuconfig/styles.go
+++ b/internal/shizukuconfig/styles.go
@@ -30,11 +30,16 @@ func (s *Styles) UnmarshalYAML(node *yaml.Node) error {
 	return nil
 }
 
+var (
+	defaultThemeName     = "monade"
+	defaultWindowOpacity = 85
+)
+
 func createDefaultStyles() Styles {
-	theme, _ := loadThemeFromRegistry("monade")
+	theme, _ := loadThemeFromRegistry(defaultThemeName)
 	return Styles{
-		ThemeName:     "monade",
-		WindowOpacity: 100,
+		ThemeName:     defaultThemeName,
+		WindowOpacity: defaultWindowOpacity,
 		Theme:         theme,
 	}
 }

--- a/internal/shizukuconfig/styles_test.go
+++ b/internal/shizukuconfig/styles_test.go
@@ -9,12 +9,12 @@ import (
 func TestCreateDefaultStyles(t *testing.T) {
 	styles := createDefaultStyles()
 
-	if styles.ThemeName != "monade" {
-		t.Errorf("Expected default theme 'monade', got %q", styles.ThemeName)
+	if styles.ThemeName != defaultThemeName {
+		t.Errorf("Expected default theme %q, got %q", defaultThemeName, styles.ThemeName)
 	}
 
-	if styles.WindowOpacity != 100 {
-		t.Errorf("Expected default windowOpacity 100, got %d", styles.WindowOpacity)
+	if styles.WindowOpacity != defaultWindowOpacity {
+		t.Errorf("Expected default windowOpacity %d, got %d", defaultWindowOpacity, styles.WindowOpacity)
 	}
 
 	if styles.Theme == nil {
@@ -165,7 +165,7 @@ func TestMergeStyles(t *testing.T) {
 
 	t.Run("uses default for missing windowOpacity", func(t *testing.T) {
 		existing := Styles{
-			ThemeName:     "monade",
+			ThemeName:     defaultThemeName,
 			WindowOpacity: 0,
 			Theme:         defaultTheme,
 		}
@@ -173,8 +173,8 @@ func TestMergeStyles(t *testing.T) {
 
 		existing.merge(defaults)
 
-		if existing.WindowOpacity != 100 {
-			t.Errorf("Expected default windowOpacity 100, got %d", existing.WindowOpacity)
+		if existing.WindowOpacity != defaultWindowOpacity {
+			t.Errorf("Expected default windowOpacity %d, got %d", defaultWindowOpacity, existing.WindowOpacity)
 		}
 	})
 
@@ -187,8 +187,8 @@ func TestMergeStyles(t *testing.T) {
 
 		existing.merge(defaults)
 
-		if existing.ThemeName != "monade" {
-			t.Errorf("Expected default theme 'monade', got %q", existing.ThemeName)
+		if existing.ThemeName != defaultThemeName {
+			t.Errorf("Expected default theme %q, got %q", defaultThemeName, existing.ThemeName)
 		}
 		if existing.Theme == nil {
 			t.Error("Expected theme to be set from defaults")


### PR DESCRIPTION
## Summary
- Extract default style vars (`defaultThemeName`, `defaultWindowOpacity`) so tests reference them instead of hardcoded values
- Fix `LoadConfig` to merge defaults — `windowOpacity` was 0 when not specified in config
- Add `LoadConfig` merge tests
- Style tmux panes: active pane gets opaque `SurfaceVariant` background, inactive panes use transparent terminal default, borders blend into pane backgrounds
- Remove extra kitty window padding

## Test plan
- [x] `task test` passes
- [x] `task run -- sync` generates correct configs
- [x] Tmux active pane visually distinct from inactive panes
- [x] Kitty opacity applied correctly with default `windowOpacity`

🤖 Generated with [Claude Code](https://claude.com/claude-code)