### PR TITLE
feat(utena): add shizuku app for utena install and worktree setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ out/
 
 .task/
 
+.claude/settings.local.json
+

--- a/apps/apps.go
+++ b/apps/apps.go
@@ -22,6 +22,7 @@ import (
 	"github.com/eleonorayaya/shizuku/apps/terminal"
 	"github.com/eleonorayaya/shizuku/apps/terraform"
 	"github.com/eleonorayaya/shizuku/apps/tmux"
+	"github.com/eleonorayaya/shizuku/apps/utena"
 	"github.com/eleonorayaya/shizuku/apps/zellij"
 	"github.com/eleonorayaya/shizuku/internal/shizukuapp"
 )
@@ -50,5 +51,6 @@ func GetApps() []shizukuapp.App {
 		desktoppr.New(),
 		claude.New(),
 		glow.New(),
+		utena.New(),
 	}
 }

--- a/apps/utena/contents/worktree-setup
+++ b/apps/utena/contents/worktree-setup
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+MAIN_SETTINGS="${UTENA_WORKSPACE_PATH}/.claude/settings.local.json"
+WORKTREE_SETTINGS="${UTENA_WORKTREE_PATH}/.claude/settings.local.json"
+
+if [ ! -f "$MAIN_SETTINGS" ]; then
+    mkdir -p "$(dirname "$MAIN_SETTINGS")"
+    echo '{}' > "$MAIN_SETTINGS"
+fi
+
+if [ -L "$WORKTREE_SETTINGS" ]; then
+    exit 0
+fi
+
+mkdir -p "$(dirname "$WORKTREE_SETTINGS")"
+rm -f "$WORKTREE_SETTINGS"
+ln -s "$MAIN_SETTINGS" "$WORKTREE_SETTINGS"

--- a/apps/utena/utena.go
+++ b/apps/utena/utena.go
@@ -1,0 +1,115 @@
+package utena
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/eleonorayaya/shizuku/internal/shizukuapp"
+	"github.com/eleonorayaya/shizuku/internal/shizukuconfig"
+)
+
+const (
+	repoURL  = "https://github.com/eleonorayaya/utena"
+	cloneDir = ".local/src/utena"
+)
+
+type App struct{}
+
+func New() *App {
+	return &App{}
+}
+
+func (a *App) Name() string {
+	return "utena"
+}
+
+func (a *App) Enabled(config *shizukuconfig.Config) bool {
+	return config.GetAppConfigBool(a.Name(), "enabled", true)
+}
+
+func (a *App) Install(config *shizukuconfig.Config) error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	repoPath := filepath.Join(homeDir, cloneDir)
+
+	if _, err := os.Stat(repoPath); os.IsNotExist(err) {
+		if err := os.MkdirAll(filepath.Dir(repoPath), 0755); err != nil {
+			return fmt.Errorf("failed to create parent directory: %w", err)
+		}
+		cmd := exec.Command("git", "clone", repoURL, repoPath)
+		if output, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("failed to clone utena: %s: %w", string(output), err)
+		}
+	} else {
+		cmd := exec.Command("git", "-C", repoPath, "pull", "origin", "main")
+		if output, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("failed to pull latest utena: %s: %w", string(output), err)
+		}
+	}
+
+	taskCmd := exec.Command("task", "install")
+	taskCmd.Dir = repoPath
+	if output, err := taskCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to install utena: %s: %w", string(output), err)
+	}
+
+	if err := updateClaudePlugin(); err != nil {
+		return fmt.Errorf("failed to update claude plugin: %w", err)
+	}
+
+	return nil
+}
+
+func updateClaudePlugin() error {
+	marketplaceCmd := exec.Command("claude", "plugin", "marketplace", "update", "utena")
+	if output, err := marketplaceCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("marketplace update failed: %s: %w", string(output), err)
+	}
+
+	pluginCmd := exec.Command("claude", "plugin", "update", "utena-claude@utena")
+	if output, err := pluginCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("plugin update failed: %s: %w", string(output), err)
+	}
+
+	return nil
+}
+
+func (a *App) Generate(outDir string, config *shizukuconfig.Config) (*shizukuapp.GenerateResult, error) {
+	fileMap, err := shizukuapp.GenerateAppFiles("utena", nil, outDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate utena files: %w", err)
+	}
+
+	return &shizukuapp.GenerateResult{
+		FileMap: fileMap,
+		DestDir: "~/.config/utena/",
+	}, nil
+}
+
+func (a *App) Sync(outDir string, config *shizukuconfig.Config) error {
+	result, err := a.Generate(outDir, config)
+	if err != nil {
+		return err
+	}
+
+	if err := shizukuapp.SyncAppFiles(result.FileMap, result.DestDir); err != nil {
+		return fmt.Errorf("failed to sync utena files: %w", err)
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	scriptPath := filepath.Join(homeDir, ".config", "utena", "worktree-setup")
+	if err := os.Chmod(scriptPath, 0755); err != nil {
+		return fmt.Errorf("failed to make worktree-setup executable: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Manages utena installation (clone, pull latest, task install, update claude plugin) and syncs a worktree-setup hook that symlinks .claude/settings.local.json from worktrees to the main repo copy, preventing permission loss when worktrees are cleaned up.