### PR TITLE
feat(kitty): add visual bell and command finish notifications

### DIFF
--- a/apps/kitty/contents/kitty.conf.tmpl
+++ b/apps/kitty/contents/kitty.conf.tmpl
@@ -1,5 +1,7 @@
 scrollback_lines  10000
 enable_audio_bell  false
+visual_bell_duration  0.5
+notify_on_cmd_finish  unfocused 5.0
 background_opacity {{.BackgroundAlpha}}
 background_blur  48
 window_padding_width 0


### PR DESCRIPTION
## Summary
- Add `visual_bell_duration 0.5` for a 0.5s screen flash on bell (audio bell is disabled)
- Add `notify_on_cmd_finish unfocused 5.0` for desktop notifications when long-running commands (5s+) finish in unfocused windows

## Test plan
- [x] `task build` compiles successfully
- [x] `task run -- sync` applies config to `~/.config/kitty/`
- [ ] Reload kitty and verify visual bell flash works
- [ ] Verify desktop notification appears after a long command in an unfocused window

🤖 Generated with [Claude Code](https://claude.com/claude-code)