### PR TITLE
feat: add upgrade command

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -7,6 +7,8 @@ tasks:
   build:
     sources:
       - "{{.GO_SOURCES}}"
+    generates:
+      - out/shizuku
     cmds:
       - go build -o out/shizuku cmd/main.go
   configmax:
@@ -32,5 +34,5 @@ tasks:
     deps:
       - build
     cmds:
-      - mv out/shizuku "$(go env GOPATH)/bin/"
+      - cp out/shizuku "$(go env GOPATH)/bin/"
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -10,6 +10,7 @@ import (
 	installcmd "github.com/eleonorayaya/shizuku/cmd/install"
 	listcmd "github.com/eleonorayaya/shizuku/cmd/list"
 	"github.com/eleonorayaya/shizuku/cmd/sync"
+	upgradecmd "github.com/eleonorayaya/shizuku/cmd/upgrade"
 	"github.com/spf13/cobra"
 )
 
@@ -34,6 +35,7 @@ func init() {
 	rootCmd.AddCommand(installcmd.InstallCommand)
 	rootCmd.AddCommand(listcmd.ListCommand)
 	rootCmd.AddCommand(sync.SyncCommand)
+	rootCmd.AddCommand(upgradecmd.UpgradeCommand)
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
 }
 

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -1,0 +1,88 @@
+package upgrade
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	repoURL  = "https://github.com/eleonorayaya/dotfiles"
+	cloneDir = ".local/src/shizuku"
+)
+
+var UpgradeCommand = &cobra.Command{
+	Use:   "upgrade",
+	Short: "Pull latest changes, rebuild, install, and sync",
+	RunE:  upgrade,
+}
+
+func upgrade(cmd *cobra.Command, args []string) error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	repoDir := filepath.Join(homeDir, cloneDir)
+
+	if _, err := os.Stat(repoDir); os.IsNotExist(err) {
+		slog.Info("cloning shizuku repo")
+		if err := os.MkdirAll(filepath.Dir(repoDir), 0755); err != nil {
+			return fmt.Errorf("failed to create parent directory: %w", err)
+		}
+		if err := run("", "git", "clone", repoURL, repoDir); err != nil {
+			return fmt.Errorf("failed to clone repo: %w", err)
+		}
+	} else {
+		slog.Info("pulling latest changes")
+		if err := run(repoDir, "git", "pull", "origin", "main"); err != nil {
+			return fmt.Errorf("failed to pull latest changes: %w", err)
+		}
+	}
+
+	slog.Info("building and installing shizuku")
+	if err := run(repoDir, "task", "install"); err != nil {
+		return fmt.Errorf("failed to build and install: %w", err)
+	}
+
+	shizukuBin, err := shizukuBinPath()
+	if err != nil {
+		return fmt.Errorf("failed to resolve shizuku binary path: %w", err)
+	}
+
+	slog.Info("running shizuku install")
+	if err := run(repoDir, shizukuBin, "install"); err != nil {
+		return fmt.Errorf("failed to run shizuku install: %w", err)
+	}
+
+	slog.Info("running shizuku sync")
+	if err := run(repoDir, shizukuBin, "sync"); err != nil {
+		return fmt.Errorf("failed to run shizuku sync: %w", err)
+	}
+
+	return nil
+}
+
+func shizukuBinPath() (string, error) {
+	out, err := exec.Command("go", "env", "GOPATH").Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get GOPATH: %w", err)
+	}
+	gopath := strings.TrimSpace(string(out))
+	return filepath.Join(gopath, "bin", "shizuku"), nil
+}
+
+func run(dir string, name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	return cmd.Run()
+}

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -11,15 +11,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	repoURL  = "https://github.com/eleonorayaya/dotfiles"
-	cloneDir = ".local/src/shizuku"
-)
+const cloneDir = ".local/src/shizuku"
+
+var branch string
 
 var UpgradeCommand = &cobra.Command{
 	Use:   "upgrade",
 	Short: "Pull latest changes, rebuild, install, and sync",
 	RunE:  upgrade,
+}
+
+func init() {
+	UpgradeCommand.Flags().StringVarP(&branch, "branch", "b", "main", "Branch to pull from")
 }
 
 func upgrade(cmd *cobra.Command, args []string) error {
@@ -31,18 +34,18 @@ func upgrade(cmd *cobra.Command, args []string) error {
 	repoDir := filepath.Join(homeDir, cloneDir)
 
 	if _, err := os.Stat(repoDir); os.IsNotExist(err) {
-		slog.Info("cloning shizuku repo")
-		if err := os.MkdirAll(filepath.Dir(repoDir), 0755); err != nil {
-			return fmt.Errorf("failed to create parent directory: %w", err)
-		}
-		if err := run("", "git", "clone", repoURL, repoDir); err != nil {
-			return fmt.Errorf("failed to clone repo: %w", err)
-		}
-	} else {
-		slog.Info("pulling latest changes")
-		if err := run(repoDir, "git", "pull", "origin", "main"); err != nil {
-			return fmt.Errorf("failed to pull latest changes: %w", err)
-		}
+		return fmt.Errorf("shizuku repo not found at %s, run 'shizuku install' first", repoDir)
+	}
+
+	slog.Info("pulling latest changes", "branch", branch)
+	if err := run(repoDir, "git", "fetch", "origin", branch); err != nil {
+		return fmt.Errorf("failed to fetch: %w", err)
+	}
+	if err := run(repoDir, "git", "checkout", branch); err != nil {
+		return fmt.Errorf("failed to checkout branch: %w", err)
+	}
+	if err := run(repoDir, "git", "pull", "origin", branch); err != nil {
+		return fmt.Errorf("failed to pull latest changes: %w", err)
 	}
 
 	slog.Info("building and installing shizuku")


### PR DESCRIPTION
## Summary
- Adds `shizuku upgrade` command that pulls latest source to `~/.local/src/shizuku`, builds/installs the binary, then runs `shizuku install` and `shizuku sync`
- Supports `-b/--branch` flag for pulling from non-main branches
- Fixes Taskfile `install` task: uses `cp` instead of `mv` and adds `generates` attr to prevent stale build caching

## Test plan
- [ ] Clone repo to `~/.local/src/shizuku` and run `shizuku upgrade`
- [ ] Test `shizuku upgrade -b <branch>` pulls the correct branch
- [ ] Verify `task install` works correctly on repeated runs (no missing binary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)