### PR TITLE
feat(k9s): add k9s app with themed skin and config

### DIFF
--- a/apps/apps.go
+++ b/apps/apps.go
@@ -10,6 +10,7 @@ import (
 	"github.com/eleonorayaya/shizuku/apps/glow"
 	"github.com/eleonorayaya/shizuku/apps/golang"
 	"github.com/eleonorayaya/shizuku/apps/jankyborders"
+	"github.com/eleonorayaya/shizuku/apps/k9s"
 	"github.com/eleonorayaya/shizuku/apps/kitty"
 	"github.com/eleonorayaya/shizuku/apps/lsd"
 	"github.com/eleonorayaya/shizuku/apps/nvim"
@@ -52,5 +53,6 @@ func GetApps() []shizukuapp.App {
 		claude.New(),
 		glow.New(),
 		utena.New(),
+		k9s.New(),
 	}
 }

--- a/apps/k9s/contents/config.yaml.tmpl
+++ b/apps/k9s/contents/config.yaml.tmpl
@@ -14,12 +14,6 @@ k9s:
     noIcons: false
     defaultsToFullScreen: false
     skin: shizuku
-  shellPod:
-    image: busybox:1.35.0
-    namespace: default
-    limits:
-      cpu: 100m
-      memory: 100Mi
   logger:
     tail: 100
     buffer: 5000

--- a/apps/k9s/contents/config.yaml.tmpl
+++ b/apps/k9s/contents/config.yaml.tmpl
@@ -1,0 +1,28 @@
+k9s:
+  liveViewAutoRefresh: false
+  screenDumpDir: /tmp/k9s-screens
+  refreshRate: 2
+  maxConnRetry: 5
+  readOnly: false
+  noExitOnCtrlC: false
+  ui:
+    enableMouse: false
+    headless: false
+    logoless: false
+    crumbsless: false
+    reactive: false
+    noIcons: false
+    defaultsToFullScreen: false
+    skin: shizuku
+  shellPod:
+    image: busybox:1.35.0
+    namespace: default
+    limits:
+      cpu: 100m
+      memory: 100Mi
+  logger:
+    tail: 100
+    buffer: 5000
+    sinceSeconds: -1
+    textWrap: false
+    showTime: false

--- a/apps/k9s/contents/skins/shizuku.yaml.tmpl
+++ b/apps/k9s/contents/skins/shizuku.yaml.tmpl
@@ -1,11 +1,11 @@
 k9s:
   body:
     fgColor: "{{.Styles.Theme.Colors.TextOnSurface}}"
-    bgColor: "{{.Styles.Theme.Colors.Surface}}"
+    bgColor: default
     logoColor: "{{.Styles.Theme.Colors.Primary}}"
   prompt:
     fgColor: "{{.Styles.Theme.Colors.TextOnSurface}}"
-    bgColor: "{{.Styles.Theme.Colors.Surface}}"
+    bgColor: default
     suggestColor: "{{.Styles.Theme.Colors.AccentGold}}"
   info:
     fgColor: "{{.Styles.Theme.Colors.Primary}}"
@@ -42,13 +42,13 @@ k9s:
       completedColor: "{{.Styles.Theme.Colors.TextOnSurfaceMuted}}"
     title:
       fgColor: "{{.Styles.Theme.Colors.Primary}}"
-      bgColor: "{{.Styles.Theme.Colors.Surface}}"
+      bgColor: default
       highlightColor: "{{.Styles.Theme.Colors.AccentGold}}"
       counterColor: "{{.Styles.Theme.Colors.Primary}}"
       filterColor: "{{.Styles.Theme.Colors.AccentMint}}"
   views:
     charts:
-      bgColor: "{{.Styles.Theme.Colors.Surface}}"
+      bgColor: default
       defaultDialColors:
         - "{{.Styles.Theme.Colors.Primary}}"
         - "{{.Styles.Theme.Colors.Error}}"
@@ -57,17 +57,17 @@ k9s:
         - "{{.Styles.Theme.Colors.Error}}"
     table:
       fgColor: "{{.Styles.Theme.Colors.TextOnSurface}}"
-      bgColor: "{{.Styles.Theme.Colors.Surface}}"
+      bgColor: default
       cursorFgColor: "{{.Styles.Theme.Colors.SelectionForeground}}"
       cursorBgColor: "{{.Styles.Theme.Colors.Selection}}"
       markColor: "{{.Styles.Theme.Colors.AccentYellow}}"
       header:
         fgColor: "{{.Styles.Theme.Colors.TextOnSurfaceEmphasis}}"
-        bgColor: "{{.Styles.Theme.Colors.Surface}}"
+        bgColor: default
         sorterColor: "{{.Styles.Theme.Colors.AccentGold}}"
     xray:
       fgColor: "{{.Styles.Theme.Colors.TextOnSurface}}"
-      bgColor: "{{.Styles.Theme.Colors.Surface}}"
+      bgColor: default
       cursorColor: "{{.Styles.Theme.Colors.Selection}}"
       graphicColor: "{{.Styles.Theme.Colors.Primary}}"
       colors:
@@ -81,9 +81,9 @@ k9s:
       valueColor: "{{.Styles.Theme.Colors.TextOnSurface}}"
     log:
       fgColor: "{{.Styles.Theme.Colors.TextOnSurface}}"
-      bgColor: "{{.Styles.Theme.Colors.Surface}}"
+      bgColor: default
       indicator:
         fgColor: "{{.Styles.Theme.Colors.TextOnSurface}}"
-        bgColor: "{{.Styles.Theme.Colors.Surface}}"
+        bgColor: default
         toggleOnColor: "{{.Styles.Theme.Colors.Primary}}"
         toggleOffColor: "{{.Styles.Theme.Colors.TextOnSurfaceMuted}}"

--- a/apps/k9s/contents/skins/shizuku.yml.tmpl
+++ b/apps/k9s/contents/skins/shizuku.yml.tmpl
@@ -1,0 +1,89 @@
+k9s:
+  body:
+    fgColor: "{{.Styles.Theme.Colors.TextOnSurface}}"
+    bgColor: "{{.Styles.Theme.Colors.Surface}}"
+    logoColor: "{{.Styles.Theme.Colors.Primary}}"
+  prompt:
+    fgColor: "{{.Styles.Theme.Colors.TextOnSurface}}"
+    bgColor: "{{.Styles.Theme.Colors.Surface}}"
+    suggestColor: "{{.Styles.Theme.Colors.AccentGold}}"
+  info:
+    fgColor: "{{.Styles.Theme.Colors.Primary}}"
+    sectionColor: "{{.Styles.Theme.Colors.TextOnSurface}}"
+  dialog:
+    fgColor: "{{.Styles.Theme.Colors.TextOnSurface}}"
+    bgColor: "{{.Styles.Theme.Colors.SurfaceVariant}}"
+    buttonFgColor: "{{.Styles.Theme.Colors.TextOnSurface}}"
+    buttonBgColor: "{{.Styles.Theme.Colors.Primary}}"
+    buttonFocusFgColor: "{{.Styles.Theme.Colors.TextOnPrimary}}"
+    buttonFocusBgColor: "{{.Styles.Theme.Colors.Primary}}"
+    labelFgColor: "{{.Styles.Theme.Colors.AccentGold}}"
+    fieldFgColor: "{{.Styles.Theme.Colors.TextOnSurface}}"
+  frame:
+    border:
+      fgColor: "{{.Styles.Theme.Colors.SurfaceBorder}}"
+      focusColor: "{{.Styles.Theme.Colors.Primary}}"
+    menu:
+      fgColor: "{{.Styles.Theme.Colors.TextOnSurface}}"
+      keyColor: "{{.Styles.Theme.Colors.Primary}}"
+      numKeyColor: "{{.Styles.Theme.Colors.Primary}}"
+    crumbs:
+      fgColor: "{{.Styles.Theme.Colors.TextOnPrimary}}"
+      bgColor: "{{.Styles.Theme.Colors.Primary}}"
+      activeColor: "{{.Styles.Theme.Colors.PrimaryVariant}}"
+    status:
+      newColor: "{{.Styles.Theme.Colors.AccentBlue}}"
+      modifyColor: "{{.Styles.Theme.Colors.AccentGold}}"
+      addColor: "{{.Styles.Theme.Colors.AccentMint}}"
+      pendingColor: "{{.Styles.Theme.Colors.AccentYellow}}"
+      errorColor: "{{.Styles.Theme.Colors.Error}}"
+      highlightColor: "{{.Styles.Theme.Colors.AccentBlue}}"
+      killColor: "{{.Styles.Theme.Colors.TextOnSurfaceMuted}}"
+      completedColor: "{{.Styles.Theme.Colors.TextOnSurfaceMuted}}"
+    title:
+      fgColor: "{{.Styles.Theme.Colors.Primary}}"
+      bgColor: "{{.Styles.Theme.Colors.Surface}}"
+      highlightColor: "{{.Styles.Theme.Colors.AccentGold}}"
+      counterColor: "{{.Styles.Theme.Colors.Primary}}"
+      filterColor: "{{.Styles.Theme.Colors.AccentMint}}"
+  views:
+    charts:
+      bgColor: "{{.Styles.Theme.Colors.Surface}}"
+      defaultDialColors:
+        - "{{.Styles.Theme.Colors.Primary}}"
+        - "{{.Styles.Theme.Colors.Error}}"
+      defaultChartColors:
+        - "{{.Styles.Theme.Colors.Primary}}"
+        - "{{.Styles.Theme.Colors.Error}}"
+    table:
+      fgColor: "{{.Styles.Theme.Colors.TextOnSurface}}"
+      bgColor: "{{.Styles.Theme.Colors.Surface}}"
+      cursorFgColor: "{{.Styles.Theme.Colors.SelectionForeground}}"
+      cursorBgColor: "{{.Styles.Theme.Colors.Selection}}"
+      markColor: "{{.Styles.Theme.Colors.AccentYellow}}"
+      header:
+        fgColor: "{{.Styles.Theme.Colors.TextOnSurfaceEmphasis}}"
+        bgColor: "{{.Styles.Theme.Colors.Surface}}"
+        sorterColor: "{{.Styles.Theme.Colors.AccentGold}}"
+    xray:
+      fgColor: "{{.Styles.Theme.Colors.TextOnSurface}}"
+      bgColor: "{{.Styles.Theme.Colors.Surface}}"
+      cursorColor: "{{.Styles.Theme.Colors.Selection}}"
+      graphicColor: "{{.Styles.Theme.Colors.Primary}}"
+      colors:
+        - "{{.Styles.Theme.Colors.Primary}}"
+        - "{{.Styles.Theme.Colors.Secondary}}"
+        - "{{.Styles.Theme.Colors.Tertiary}}"
+        - "{{.Styles.Theme.Colors.AccentMint}}"
+    yaml:
+      keyColor: "{{.Styles.Theme.Colors.Primary}}"
+      colonColor: "{{.Styles.Theme.Colors.TextOnSurfaceMuted}}"
+      valueColor: "{{.Styles.Theme.Colors.TextOnSurface}}"
+    log:
+      fgColor: "{{.Styles.Theme.Colors.TextOnSurface}}"
+      bgColor: "{{.Styles.Theme.Colors.Surface}}"
+      indicator:
+        fgColor: "{{.Styles.Theme.Colors.TextOnSurface}}"
+        bgColor: "{{.Styles.Theme.Colors.Surface}}"
+        toggleOnColor: "{{.Styles.Theme.Colors.Primary}}"
+        toggleOffColor: "{{.Styles.Theme.Colors.TextOnSurfaceMuted}}"

--- a/apps/k9s/k9s.go
+++ b/apps/k9s/k9s.go
@@ -1,0 +1,72 @@
+package k9s
+
+import (
+	"fmt"
+
+	"github.com/eleonorayaya/shizuku/internal/shizukuapp"
+	"github.com/eleonorayaya/shizuku/internal/shizukuconfig"
+	"github.com/eleonorayaya/shizuku/internal/util"
+)
+
+type App struct{}
+
+func New() *App {
+	return &App{}
+}
+
+func (a *App) Name() string {
+	return "k9s"
+}
+
+func (a *App) Enabled(config *shizukuconfig.Config) bool {
+	return config.GetAppConfigBool(a.Name(), "enabled", true)
+}
+
+func (a *App) Install(config *shizukuconfig.Config) error {
+	if err := util.AddTap("derailed/k9s"); err != nil {
+		return fmt.Errorf("failed to add tap: %w", err)
+	}
+
+	if err := util.InstallBrewPackage("derailed/k9s/k9s", false); err != nil {
+		return fmt.Errorf("failed to install k9s: %w", err)
+	}
+
+	return nil
+}
+
+func (a *App) Env() (*shizukuapp.EnvSetup, error) {
+	return &shizukuapp.EnvSetup{
+		Variables: []shizukuapp.EnvVar{
+			{Key: "KUBE_EDITOR", Value: "nvim"},
+		},
+	}, nil
+}
+
+func (a *App) Generate(outDir string, config *shizukuconfig.Config) (*shizukuapp.GenerateResult, error) {
+	data := map[string]any{
+		"Styles": config.Styles,
+	}
+
+	fileMap, err := shizukuapp.GenerateAppFiles("k9s", data, outDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate app files: %w", err)
+	}
+
+	return &shizukuapp.GenerateResult{
+		FileMap: fileMap,
+		DestDir: "~/.config/k9s/",
+	}, nil
+}
+
+func (a *App) Sync(outDir string, config *shizukuconfig.Config) error {
+	result, err := a.Generate(outDir, config)
+	if err != nil {
+		return err
+	}
+
+	if err := shizukuapp.SyncAppFiles(result.FileMap, result.DestDir); err != nil {
+		return fmt.Errorf("failed to sync app files: %w", err)
+	}
+
+	return nil
+}

--- a/apps/k9s/k9s.go
+++ b/apps/k9s/k9s.go
@@ -54,7 +54,7 @@ func (a *App) Generate(outDir string, config *shizukuconfig.Config) (*shizukuapp
 
 	return &shizukuapp.GenerateResult{
 		FileMap: fileMap,
-		DestDir: "~/.config/k9s/",
+		DestDir: "~/Library/Application Support/k9s/",
 	}, nil
 }
 


### PR DESCRIPTION
## Summary
- Add k9s (Kubernetes CLI dashboard) app to shizuku
- Themed skin mapping shizuku color palette to all k9s UI elements (body, prompt, dialog, frame, views)
- Default config.yaml with shizuku skin reference
- Install via Homebrew (`derailed/k9s` tap) and export `KUBE_EDITOR=nvim`

## Test plan
- [ ] `task build` compiles successfully
- [ ] `task run diff` shows expected k9s config and skin files
- [ ] `task run sync` writes files to `~/.config/k9s/`
- [ ] k9s launches with the shizuku theme applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)