### PR TITLE
feat(buildkite): add buildkite CLI app

### DIFF
--- a/apps/apps.go
+++ b/apps/apps.go
@@ -3,6 +3,7 @@ package apps
 import (
 	"github.com/eleonorayaya/shizuku/apps/aerospace"
 	"github.com/eleonorayaya/shizuku/apps/bat"
+	"github.com/eleonorayaya/shizuku/apps/buildkite"
 	"github.com/eleonorayaya/shizuku/apps/claude"
 	"github.com/eleonorayaya/shizuku/apps/desktoppr"
 	"github.com/eleonorayaya/shizuku/apps/fastfetch"
@@ -54,5 +55,6 @@ func GetApps() []shizukuapp.App {
 		glow.New(),
 		utena.New(),
 		k9s.New(),
+		buildkite.New(),
 	}
 }

--- a/apps/buildkite/buildkite.go
+++ b/apps/buildkite/buildkite.go
@@ -1,0 +1,34 @@
+package buildkite
+
+import (
+	"fmt"
+
+	"github.com/eleonorayaya/shizuku/internal/shizukuconfig"
+	"github.com/eleonorayaya/shizuku/internal/util"
+)
+
+type App struct{}
+
+func New() *App {
+	return &App{}
+}
+
+func (a *App) Name() string {
+	return "buildkite"
+}
+
+func (a *App) Enabled(config *shizukuconfig.Config) bool {
+	return config.GetAppConfigBool(a.Name(), "enabled", false)
+}
+
+func (a *App) Install(config *shizukuconfig.Config) error {
+	if err := util.AddTap("buildkite/buildkite"); err != nil {
+		return fmt.Errorf("failed to add tap: %w", err)
+	}
+
+	if err := util.InstallBrewPackage("buildkite/buildkite/bk@3", false); err != nil {
+		return fmt.Errorf("failed to install bk: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- Add Buildkite CLI (`bk@3`) as a new shizuku app
- Installs via Homebrew with `buildkite/buildkite` tap
- Disabled by default, enable via `apps.buildkite.enabled: true`

## Test plan
- [x] `task build` passes
- [x] `task test` passes