### PR TITLE
feat(aerospace): add dynamic gaps with laptop mode toggle

### DIFF
--- a/apps/aerospace/aerospace.go
+++ b/apps/aerospace/aerospace.go
@@ -35,8 +35,11 @@ func (a *App) Install(config *shizukuconfig.Config) error {
 }
 
 func (a *App) Generate(outDir string, config *shizukuconfig.Config) (*shizukuapp.GenerateResult, error) {
+	laptop := config.GetAppConfigBool(a.Name(), "laptop", false)
+	gaps := shizukuconfig.DefaultGapsForLaptop(laptop)
+
 	data := map[string]any{
-		"Laptop": config.GetAppConfigBool(a.Name(), "laptop", false),
+		"Gaps": gaps,
 	}
 
 	fileMap, err := shizukuapp.GenerateAppFiles("aerospace", data, outDir)

--- a/apps/aerospace/aerospace.go
+++ b/apps/aerospace/aerospace.go
@@ -35,7 +35,9 @@ func (a *App) Install(config *shizukuconfig.Config) error {
 }
 
 func (a *App) Generate(outDir string, config *shizukuconfig.Config) (*shizukuapp.GenerateResult, error) {
-	data := map[string]any{}
+	data := map[string]any{
+		"Laptop": config.GetAppConfigBool(a.Name(), "laptop", false),
+	}
 
 	fileMap, err := shizukuapp.GenerateAppFiles("aerospace", data, outDir)
 	if err != nil {

--- a/apps/aerospace/contents/aerospace.toml.tmpl
+++ b/apps/aerospace/contents/aerospace.toml.tmpl
@@ -13,21 +13,12 @@ exec-on-workspace-change = [
 ]
 
 [gaps]
-{{- if .Laptop }}
-inner.horizontal = 8
-inner.vertical = 8
-outer.left = 8
-outer.bottom = 8
-outer.top = 8
-outer.right = 8
-{{- else }}
-inner.horizontal = 16
-inner.vertical = 16
-outer.left = 64
-outer.bottom = 128
-outer.top = 64
-outer.right = 64
-{{- end }}
+inner.horizontal = {{ .Gaps.InnerHorizontal }}
+inner.vertical = {{ .Gaps.InnerVertical }}
+outer.left = {{ .Gaps.OuterLeft }}
+outer.bottom = {{ .Gaps.OuterBottom }}
+outer.top = {{ .Gaps.OuterTop }}
+outer.right = {{ .Gaps.OuterRight }}
 
 
 [mode.main.binding]

--- a/apps/aerospace/contents/aerospace.toml.tmpl
+++ b/apps/aerospace/contents/aerospace.toml.tmpl
@@ -13,12 +13,21 @@ exec-on-workspace-change = [
 ]
 
 [gaps]
+{{- if .Laptop }}
+inner.horizontal = 8
+inner.vertical = 8
+outer.left = 8
+outer.bottom = 8
+outer.top = 8
+outer.right = 8
+{{- else }}
 inner.horizontal = 16
 inner.vertical = 16
 outer.left = 64
 outer.bottom = 128
 outer.top = 64
 outer.right = 64
+{{- end }}
 
 
 [mode.main.binding]

--- a/internal/shizukuconfig/styles.go
+++ b/internal/shizukuconfig/styles.go
@@ -6,9 +6,19 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+type Gaps struct {
+	InnerHorizontal int `yaml:"innerHorizontal"`
+	InnerVertical   int `yaml:"innerVertical"`
+	OuterLeft       int `yaml:"outerLeft"`
+	OuterBottom     int `yaml:"outerBottom"`
+	OuterTop        int `yaml:"outerTop"`
+	OuterRight      int `yaml:"outerRight"`
+}
+
 type Styles struct {
 	ThemeName     string `yaml:"theme"`
 	WindowOpacity int    `yaml:"windowOpacity"`
+	Gaps          Gaps   `yaml:"gaps"`
 	Theme         *Theme `yaml:"-"`
 }
 
@@ -33,6 +43,22 @@ func (s *Styles) UnmarshalYAML(node *yaml.Node) error {
 var (
 	defaultThemeName     = "monade"
 	defaultWindowOpacity = 85
+	defaultGapsDesktop   = Gaps{
+		InnerHorizontal: 16,
+		InnerVertical:   16,
+		OuterLeft:       64,
+		OuterBottom:     128,
+		OuterTop:        64,
+		OuterRight:      64,
+	}
+	defaultGapsLaptop = Gaps{
+		InnerHorizontal: 8,
+		InnerVertical:   8,
+		OuterLeft:       8,
+		OuterBottom:     8,
+		OuterTop:        8,
+		OuterRight:      8,
+	}
 )
 
 func createDefaultStyles() Styles {
@@ -40,8 +66,16 @@ func createDefaultStyles() Styles {
 	return Styles{
 		ThemeName:     defaultThemeName,
 		WindowOpacity: defaultWindowOpacity,
+		Gaps:          defaultGapsDesktop,
 		Theme:         theme,
 	}
+}
+
+func DefaultGapsForLaptop(laptop bool) Gaps {
+	if laptop {
+		return defaultGapsLaptop
+	}
+	return defaultGapsDesktop
 }
 
 func (s *Styles) validate() error {
@@ -68,5 +102,9 @@ func (s *Styles) merge(defaults Styles) {
 
 	if s.WindowOpacity == 0 {
 		s.WindowOpacity = defaults.WindowOpacity
+	}
+
+	if s.Gaps == (Gaps{}) {
+		s.Gaps = defaults.Gaps
 	}
 }


### PR DESCRIPTION
## Summary
- Add `laptop` boolean to aerospace app config for toggling between desktop and laptop gap sizes
- Desktop mode (default): 64/128px outer gaps, 16px inner gaps
- Laptop mode: 8px gaps all around for maximizing screen real estate on smaller displays

## Test plan
- [ ] `task run -- diff -p` with `laptop: false` shows desktop gaps (64/128/16)
- [ ] `task run -- diff -p` with `laptop: true` shows laptop gaps (8/8/8)
- [ ] `task test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)