### PR TITLE
feat: add zig language support via zvm

### DIFF
--- a/apps/apps.go
+++ b/apps/apps.go
@@ -26,6 +26,7 @@ import (
 	"github.com/eleonorayaya/shizuku/apps/tmux"
 	"github.com/eleonorayaya/shizuku/apps/utena"
 	"github.com/eleonorayaya/shizuku/apps/zellij"
+	"github.com/eleonorayaya/shizuku/apps/zig"
 	"github.com/eleonorayaya/shizuku/internal/shizukuapp"
 )
 
@@ -56,5 +57,6 @@ func GetApps() []shizukuapp.App {
 		utena.New(),
 		k9s.New(),
 		buildkite.New(),
+		zig.New(),
 	}
 }

--- a/apps/zig/zig.go
+++ b/apps/zig/zig.go
@@ -1,0 +1,47 @@
+package zig
+
+import (
+	"fmt"
+
+	"github.com/eleonorayaya/shizuku/internal/shizukuapp"
+	"github.com/eleonorayaya/shizuku/internal/shizukuconfig"
+	"github.com/eleonorayaya/shizuku/internal/util"
+)
+
+type App struct{}
+
+func New() *App {
+	return &App{}
+}
+
+func (a *App) Name() string {
+	return "zig"
+}
+
+func (a *App) Enabled(config *shizukuconfig.Config) bool {
+	return config.GetLanguageEnabled(shizukuconfig.LanguageZig)
+}
+
+func (a *App) Install(config *shizukuconfig.Config) error {
+	if err := util.AddTap("tristanisham/zvm"); err != nil {
+		return fmt.Errorf("failed to add zvm tap: %w", err)
+	}
+
+	if err := util.InstallBrewPackage("zvm", false); err != nil {
+		return fmt.Errorf("failed to install zvm: %w", err)
+	}
+
+	return nil
+}
+
+func (a *App) Env() (*shizukuapp.EnvSetup, error) {
+	return &shizukuapp.EnvSetup{
+		Variables: []shizukuapp.EnvVar{
+			{Key: "ZVM_INSTALL", Value: "$HOME/.zvm/self"},
+		},
+		PathDirs: []shizukuapp.PathDir{
+			{Path: "$HOME/.zvm/bin", Priority: 20},
+			{Path: "$HOME/.zvm/self", Priority: 20},
+		},
+	}, nil
+}

--- a/internal/shizukuconfig/language.go
+++ b/internal/shizukuconfig/language.go
@@ -13,6 +13,7 @@ const (
 	LanguageLua        Language = "lua"
 	LanguageRust       Language = "rust"
 	LanguageTypescript Language = "typescript"
+	LanguageZig        Language = "zig"
 )
 
 var languages []Language = []Language{
@@ -20,6 +21,7 @@ var languages []Language = []Language{
 	LanguageLua,
 	LanguageRust,
 	LanguageTypescript,
+	LanguageZig,
 }
 
 type LanguageConfig struct {


### PR DESCRIPTION
## Summary
- Adds `zig` as a managed language in shizuku, enabled via `languages.zig.enabled: true` in config
- Installs zvm via `brew tap tristanisham/zvm && brew install zvm`
- Sets `ZVM_INSTALL`, `$HOME/.zvm/bin`, and `$HOME/.zvm/self` PATH entries through shizuku env management instead of manually in `.zshenv`

## Test plan
- [ ] Enable zig in `~/.config/shizuku/shizuku.yml` under `languages: zig: enabled: true`
- [ ] Run `shizuku diff` and verify `ZVM_INSTALL` and both `.zvm` PATH entries appear in generated `shizuku.zshenv`
- [ ] Remove the three manually-added ZVM lines from `~/.zshenv` and run `shizuku sync` to apply