### PR TITLE
fix: correct shift+enter escape sequence for Claude Code in kitty+tmux

### DIFF
--- a/apps/kitty/contents/kitty.conf.tmpl
+++ b/apps/kitty/contents/kitty.conf.tmpl
@@ -35,7 +35,7 @@ shell_integration  enabled
 
 open_url_with  default
 mouse_map  ctrl+left press grabbed,ungrabbed mouse_handle_click link
-map shift+enter send_text all \x1b[74;5u
+map shift+enter send_text all \x1b[13;2u
 map cmd+k no_op
 map cmd+b send_text all \x1bb
 map cmd+p send_text all \x1bp

--- a/apps/tmux/contents/tmux.conf.tmpl
+++ b/apps/tmux/contents/tmux.conf.tmpl
@@ -3,6 +3,7 @@ set -ag terminal-overrides ",xterm-256color:RGB,xterm-kitty:RGB"
 set -s extended-keys always
 set -as terminal-features 'xterm-256color:extkeys'
 set -as terminal-features 'xterm-kitty:extkeys'
+set -g allow-passthrough on
 
 set -g mouse on
 set -g history-limit 10000


### PR DESCRIPTION
## Summary
- Fix kitty.conf shift+enter mapping: `\x1b[74;5u` was wrong (ctrl+J), changed to `\x1b[13;2u` (correct CSI u sequence for shift+enter: key=13/CR, modifier=2/shift)
- Add `allow-passthrough on` to tmux.conf so Claude Code's TUI can request the kitty keyboard protocol through tmux for proper extended key forwarding

## Test plan
- [ ] Run `shizuku sync` to apply configs
- [ ] Reload tmux config (`prefix + r`) and open a new session
- [ ] Open Claude Code inside tmux and verify shift+enter inserts a newline instead of submitting
