### PR TITLE
feat(terraform): add terraform as a language

### DIFF
--- a/apps/terraform/terraform.go
+++ b/apps/terraform/terraform.go
@@ -1,8 +1,11 @@
 package terraform
 
 import (
+	"fmt"
+
 	"github.com/eleonorayaya/shizuku/internal/shizukuapp"
 	"github.com/eleonorayaya/shizuku/internal/shizukuconfig"
+	"github.com/eleonorayaya/shizuku/internal/util"
 )
 
 type App struct{}
@@ -16,14 +19,38 @@ func (a *App) Name() string {
 }
 
 func (a *App) Enabled(config *shizukuconfig.Config) bool {
-	return config.GetAppConfigBool(a.Name(), "enabled", false)
+	return config.GetLanguageEnabled(shizukuconfig.LanguageTerraform)
+}
+
+func (a *App) Install(config *shizukuconfig.Config) error {
+	if err := util.AddTap("hashicorp/tap"); err != nil {
+		return fmt.Errorf("failed to add hashicorp tap: %w", err)
+	}
+
+	if err := util.InstallBrewPackage("hashicorp/tap/terraform-ls", false); err != nil {
+		return fmt.Errorf("failed to install terraform-ls: %w", err)
+	}
+
+	if err := util.InstallBrewPackage("opentofu", false); err != nil {
+		return fmt.Errorf("failed to install opentofu: %w", err)
+	}
+
+	if err := util.AddTap("spacelift-io/spacelift"); err != nil {
+		return fmt.Errorf("failed to add spacelift tap: %w", err)
+	}
+
+	if err := util.InstallBrewPackage("spacelift-io/spacelift/spacectl", false); err != nil {
+		return fmt.Errorf("failed to install spacectl: %w", err)
+	}
+
+	return nil
 }
 
 func (a *App) Env() (*shizukuapp.EnvSetup, error) {
 	return &shizukuapp.EnvSetup{
 		Aliases: []shizukuapp.Alias{
-			{Name: "tf", Command: "terraform"},
-			{Name: "tfmt", Command: "terraform fmt -recursive"},
+			{Name: "tf", Command: "tofu"},
+			{Name: "tfmt", Command: "tofu fmt -recursive"},
 		},
 	}, nil
 }

--- a/internal/shizukuconfig/language.go
+++ b/internal/shizukuconfig/language.go
@@ -12,6 +12,7 @@ const (
 	LanguageGo         Language = "go"
 	LanguageLua        Language = "lua"
 	LanguageRust       Language = "rust"
+	LanguageTerraform  Language = "terraform"
 	LanguageTypescript Language = "typescript"
 	LanguageZig        Language = "zig"
 )
@@ -20,6 +21,7 @@ var languages []Language = []Language{
 	LanguageGo,
 	LanguageLua,
 	LanguageRust,
+	LanguageTerraform,
 	LanguageTypescript,
 	LanguageZig,
 }


### PR DESCRIPTION
## Summary
- Register `LanguageTerraform` in the language config system so terraform is enabled via `languages.terraform.enabled`
- Add `Install()` to the terraform app: terraform-ls (LSP), opentofu, and spacectl via Homebrew
- Update aliases: `tf` → `tofu`, `tfmt` → `tofu fmt -recursive`

## Test plan
- [ ] Verify `task build` succeeds
- [ ] Enable terraform language in shizuku.yml and run `task run -- install` to confirm brew packages install
- [ ] Verify `tf` and `tfmt` aliases are set up correctly after sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)