### PR TITLE
feat(rtk): add rtk app and merge claude hooks from agent configs

### DIFF
--- a/agents/claude/claude.go
+++ b/agents/claude/claude.go
@@ -162,6 +162,66 @@ func (a *App) collectSandboxWrite(agents app.AgentContext) []string {
 	return dedupeStrings(sources...)
 }
 
+func (a *App) collectHooks(agents app.AgentContext) []app.Hook {
+	hooks := []app.Hook{}
+	for _, ac := range agents.AgentConfigs {
+		hooks = append(hooks, ac.Hooks...)
+	}
+	return hooks
+}
+
+func mergeHooks(existing map[string]any, hooks []app.Hook) map[string]any {
+	if existing == nil {
+		existing = map[string]any{}
+	}
+	for _, h := range hooks {
+		eventEntries, _ := existing[h.Event].([]any)
+		matcherIdx := -1
+		for i, entry := range eventEntries {
+			entryMap, ok := entry.(map[string]any)
+			if !ok {
+				continue
+			}
+			if m, _ := entryMap["matcher"].(string); m == h.Matcher {
+				matcherIdx = i
+				break
+			}
+		}
+
+		if matcherIdx == -1 {
+			eventEntries = append(eventEntries, map[string]any{
+				"matcher": h.Matcher,
+				"hooks": []any{
+					map[string]any{"type": "command", "command": h.Command},
+				},
+			})
+			existing[h.Event] = eventEntries
+			continue
+		}
+
+		entryMap, _ := eventEntries[matcherIdx].(map[string]any)
+		commandHooks, _ := entryMap["hooks"].([]any)
+		exists := false
+		for _, ch := range commandHooks {
+			chMap, ok := ch.(map[string]any)
+			if !ok {
+				continue
+			}
+			if cmd, _ := chMap["command"].(string); cmd == h.Command {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			commandHooks = append(commandHooks, map[string]any{"type": "command", "command": h.Command})
+			entryMap["hooks"] = commandHooks
+			eventEntries[matcherIdx] = entryMap
+			existing[h.Event] = eventEntries
+		}
+	}
+	return existing
+}
+
 func (a *App) mergeSettings(outDir string, agents app.AgentContext) (string, error) {
 	settings, err := util.ReadJSONMap("~/.claude/settings.json")
 	if err != nil {
@@ -253,6 +313,9 @@ func (a *App) mergeSettings(outDir string, agents app.AgentContext) (string, err
 	filesystem["allowWrite"] = mergeStringsIntoAnySlice(allowWriteRaw, a.collectSandboxWrite(agents))
 	sandbox["filesystem"] = filesystem
 	settings["sandbox"] = sandbox
+
+	hooks, _ := settings["hooks"].(map[string]any)
+	settings["hooks"] = mergeHooks(hooks, a.collectHooks(agents))
 
 	outPath := filepath.Join(outDir, "claude", "settings.json")
 	if err := util.WriteJSONMap(outPath, settings); err != nil {

--- a/agents/claude/claude_test.go
+++ b/agents/claude/claude_test.go
@@ -219,3 +219,113 @@ func TestMergeSettingsMarketplaces(t *testing.T) {
 func contains(slice []string, item string) bool {
 	return slices.Contains(slice, item)
 }
+
+func TestMergeHooksAddsNewHook(t *testing.T) {
+	result := mergeHooks(nil, []app.Hook{
+		{Event: "PreToolUse", Matcher: "Bash", Command: "rtk hook claude"},
+	})
+
+	entries, ok := result["PreToolUse"].([]any)
+	if !ok || len(entries) != 1 {
+		t.Fatalf("expected one PreToolUse entry, got %#v", result["PreToolUse"])
+	}
+	entry := entries[0].(map[string]any)
+	if entry["matcher"] != "Bash" {
+		t.Errorf("expected matcher Bash, got %v", entry["matcher"])
+	}
+	commands := entry["hooks"].([]any)
+	if len(commands) != 1 {
+		t.Fatalf("expected one command hook, got %d", len(commands))
+	}
+	cmd := commands[0].(map[string]any)
+	if cmd["type"] != "command" || cmd["command"] != "rtk hook claude" {
+		t.Errorf("unexpected command hook: %#v", cmd)
+	}
+}
+
+func TestMergeHooksPreservesExistingAndDedupes(t *testing.T) {
+	existing := map[string]any{
+		"PreToolUse": []any{
+			map[string]any{
+				"matcher": "Bash",
+				"hooks": []any{
+					map[string]any{"type": "command", "command": "rtk hook claude"},
+				},
+			},
+		},
+	}
+
+	result := mergeHooks(existing, []app.Hook{
+		{Event: "PreToolUse", Matcher: "Bash", Command: "rtk hook claude"},
+		{Event: "PreToolUse", Matcher: "Bash", Command: "other-hook"},
+		{Event: "Stop", Matcher: "", Command: "stop-hook"},
+	})
+
+	preEntries := result["PreToolUse"].([]any)
+	if len(preEntries) != 1 {
+		t.Fatalf("expected one Bash matcher entry, got %d", len(preEntries))
+	}
+	commands := preEntries[0].(map[string]any)["hooks"].([]any)
+	if len(commands) != 2 {
+		t.Fatalf("expected 2 deduped commands, got %d", len(commands))
+	}
+
+	stopEntries := result["Stop"].([]any)
+	if len(stopEntries) != 1 {
+		t.Fatalf("expected one Stop entry, got %d", len(stopEntries))
+	}
+}
+
+func TestMergeSettingsHooksFromAgentConfig(t *testing.T) {
+	a := New(testOptions())
+	ctx := app.AgentContext{
+		AgentConfigs: []app.AgentConfig{
+			{Hooks: []app.Hook{{Event: "PreToolUse", Matcher: "Bash", Command: "rtk hook claude"}}},
+		},
+	}
+
+	outDir := t.TempDir()
+	resultPath, err := a.mergeSettings(outDir, ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(resultPath)
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+
+	hooks, ok := settings["hooks"].(map[string]any)
+	if !ok {
+		t.Fatal("expected hooks to be a map")
+	}
+	pre, ok := hooks["PreToolUse"].([]any)
+	if !ok || len(pre) == 0 {
+		t.Fatal("expected PreToolUse entry from agent config")
+	}
+	matched := false
+	for _, entry := range pre {
+		entryMap, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		if entryMap["matcher"] != "Bash" {
+			continue
+		}
+		commandHooks, _ := entryMap["hooks"].([]any)
+		for _, ch := range commandHooks {
+			chMap, _ := ch.(map[string]any)
+			if chMap["command"] == "rtk hook claude" {
+				matched = true
+			}
+		}
+	}
+	if !matched {
+		t.Errorf("expected rtk hook claude to be merged into settings, got %#v", hooks)
+	}
+}

--- a/app/context.go
+++ b/app/context.go
@@ -5,12 +5,19 @@ type Marketplace struct {
 	Path string
 }
 
+type Hook struct {
+	Event   string
+	Matcher string
+	Command string
+}
+
 type AgentConfig struct {
 	Plugins             []string
 	Marketplaces        map[string]Marketplace
 	AllowedCommands     []string
 	SandboxAllowedHosts []string
 	SandboxAllowWrite   []string
+	Hooks               []Hook
 }
 
 type AgentConfigProvider interface {

--- a/examples/eleonora/main.go
+++ b/examples/eleonora/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/eleonorayaya/shizuku/programs/nvim"
 	"github.com/eleonorayaya/shizuku/programs/protonpass"
 	"github.com/eleonorayaya/shizuku/programs/protonvpn"
+	"github.com/eleonorayaya/shizuku/programs/rtk"
 	"github.com/eleonorayaya/shizuku/programs/sfsymbols"
 	"github.com/eleonorayaya/shizuku/programs/sketchybar"
 	"github.com/eleonorayaya/shizuku/programs/terminal"
@@ -69,6 +70,7 @@ func main() {
 			kitty.New(),
 			lsd.New(),
 			nvim.New(),
+			rtk.New(),
 			sfsymbols.New(),
 			sketchybar.New(),
 			terminal.New(),

--- a/programs/rtk/rtk.go
+++ b/programs/rtk/rtk.go
@@ -1,0 +1,38 @@
+package rtk
+
+import (
+	"fmt"
+
+	"github.com/eleonorayaya/shizuku/app"
+	"github.com/eleonorayaya/shizuku/util"
+)
+
+type App struct{}
+
+func New() *App {
+	return &App{}
+}
+
+func (a *App) Name() string {
+	return "rtk"
+}
+
+func (a *App) Install(ctx *app.Context) error {
+	if err := util.InstallBrewPackage("rtk", false); err != nil {
+		return fmt.Errorf("failed to install rtk: %w", err)
+	}
+
+	return nil
+}
+
+func (a *App) AgentConfig() app.AgentConfig {
+	return app.AgentConfig{
+		Hooks: []app.Hook{
+			{
+				Event:   "PreToolUse",
+				Matcher: "Bash",
+				Command: "rtk hook claude",
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- Add `programs/rtk` app — brew-installs `rtk` and declares its `PreToolUse` Bash → `rtk hook claude` hook via `AgentConfig`
- Extend `app.AgentConfig` with `Hooks []Hook` so any app can declare claude hooks
- Update the claude agent to merge declared hooks into `~/.claude/settings.json` additively — preserves existing entries and dedupes by command, so re-running `sync` is idempotent

## Test plan
- [x] `task lint`
- [x] `task test ./agents/claude/...` (3 new tests covering insertion, dedupe, and end-to-end merge)
- [x] `task build`
- [x] `task run -- diff` against an existing settings.json with the rtk hook already present — round-trips cleanly (only key reordering, no semantic changes to the hook)
- [ ] `task run -- install` to brew-install rtk
- [ ] `task run -- sync` to verify the hook lands in `~/.claude/settings.json`
