### PR TITLE
feat(datadog): add pup CLI and Claude plugin to work profile

### DIFF
--- a/examples/eleonora/main.go
+++ b/examples/eleonora/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/eleonorayaya/shizuku/programs/aerospace"
 	"github.com/eleonorayaya/shizuku/programs/bat"
 	"github.com/eleonorayaya/shizuku/programs/buildkite"
+	"github.com/eleonorayaya/shizuku/programs/datadog"
 	"github.com/eleonorayaya/shizuku/programs/desktoppr"
 	"github.com/eleonorayaya/shizuku/programs/fastfetch"
 	"github.com/eleonorayaya/shizuku/programs/git"
@@ -85,6 +86,7 @@ func main() {
 			),
 			shizuku.WithPrograms(
 				buildkite.New(),
+				datadog.New(),
 				k9s.New(),
 				mise.New(),
 			),

--- a/programs/datadog/datadog.go
+++ b/programs/datadog/datadog.go
@@ -1,0 +1,43 @@
+package datadog
+
+import (
+	"fmt"
+
+	"github.com/eleonorayaya/shizuku/app"
+	"github.com/eleonorayaya/shizuku/util"
+)
+
+type App struct{}
+
+func New() *App {
+	return &App{}
+}
+
+func (a *App) Name() string {
+	return "datadog"
+}
+
+func (a *App) AgentConfig() app.AgentConfig {
+	return app.AgentConfig{
+		SandboxAllowedHosts: []string{
+			"api.datadoghq.com",
+			"app.datadoghq.com",
+		},
+		Marketplaces: map[string]app.Marketplace{
+			"datadog-pup": {Repo: "datadog-labs/pup"},
+		},
+		Plugins: []string{"pup@datadog-pup"},
+	}
+}
+
+func (a *App) Install(ctx *app.Context) error {
+	if err := util.AddTap("datadog-labs/pack"); err != nil {
+		return fmt.Errorf("failed to add tap: %w", err)
+	}
+
+	if err := util.InstallBrewPackage("datadog-labs/pack/pup", false); err != nil {
+		return fmt.Errorf("failed to install pup: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- Add a `datadog` shizuku program app under the `work` profile that installs `pup` from `datadog-labs/pack` via Homebrew.
- Declare the upstream `datadog-labs/pup` Claude marketplace and `pup@datadog-pup` plugin via `AgentConfig`, so all 56 of pup's bundled skills/agents become runtime-togglable through `/plugin enable|disable` instead of being statically dropped into `~/.claude/skills/`.
- Allow `api.datadoghq.com` and `app.datadoghq.com` in the agent sandbox so Claude can invoke `pup` against the Datadog API without sandbox blocks.

## Test plan
- [x] `task build` — clean
- [x] `task test` — `agents/claude` tests still pass (cover the marketplace merge path)
- [x] `task run -- list --profile work` shows `datadog` between `buildkite` and `k9s`
- [x] `task run -- install --profile work` taps `datadog-labs/pack` and installs `datadog-labs/pack/pup`
- [x] `task run -- sync --profile work` writes `extraKnownMarketplaces["datadog-pup"]` and `enabledPlugins["pup@datadog-pup"]` into `~/.claude/settings.json`
- [ ] In a Claude Code session: `/plugin install pup@datadog-pup` once, then verify `/plugin disable pup@datadog-pup` toggles the bundle off live (no `/clear` required)
