### PR TITLE
fix(claude): rename SandboxAllowedHosts to SandboxAllowedDomains

### DIFF
--- a/.claude/skills/app/Skill.md
+++ b/.claude/skills/app/Skill.md
@@ -259,14 +259,14 @@ func (a *App) Env() (*app.EnvSetup, error) {
 
 ### Step 4b: Add AgentConfig (optional)
 
-If the app needs agentic tools to install LSP plugins, allow specific sandbox hosts, or write to specific paths, implement `AgentConfigProvider`:
+If the app needs agentic tools to install LSP plugins, allow specific sandbox domains, or write to specific paths, implement `AgentConfigProvider`:
 
 ```go
 func (a *App) AgentConfig() app.AgentConfig {
     return app.AgentConfig{
-        Plugins:             []string{"my-lsp@claude-plugins-official"},
-        SandboxAllowedHosts: []string{"my-package-registry.example"},
-        SandboxAllowWrite:   []string{"~/.cache/my-tool"},
+        Plugins:               []string{"my-lsp@claude-plugins-official"},
+        SandboxAllowedDomains: []string{"my-package-registry.example"},
+        SandboxAllowWrite:     []string{"~/.cache/my-tool"},
     }
 }
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,9 +151,9 @@ Any app — language, program, or otherwise — may declare what agentic coding 
 ```go
 func (a *App) AgentConfig() app.AgentConfig {
     return app.AgentConfig{
-        Plugins:             []string{"rust-analyzer-lsp@claude-plugins-official"},
-        SandboxAllowedHosts: []string{"crates.io", "docs.rs"},
-        SandboxAllowWrite:   []string{"~/.cargo", "~/.rustup"},
+        Plugins:               []string{"rust-analyzer-lsp@claude-plugins-official"},
+        SandboxAllowedDomains: []string{"crates.io", "docs.rs"},
+        SandboxAllowWrite:     []string{"~/.cargo", "~/.rustup"},
     }
 }
 ```

--- a/agents/claude/claude.go
+++ b/agents/claude/claude.go
@@ -13,14 +13,14 @@ import (
 var contents embed.FS
 
 type Options struct {
-	Marketplaces        map[string]app.Marketplace
-	AlwaysOnPlugins     []string
-	Env                 map[string]string
-	StatusLine          map[string]any
-	SandboxAllowedHosts []string
-	SandboxAllowWrite   []string
-	AllowedCommands     []string
-	DefaultMode         string
+	Marketplaces          map[string]app.Marketplace
+	AlwaysOnPlugins       []string
+	Env                   map[string]string
+	StatusLine            map[string]any
+	SandboxAllowedDomains []string
+	SandboxAllowWrite     []string
+	AllowedCommands       []string
+	DefaultMode           string
 }
 
 type App struct {
@@ -146,10 +146,10 @@ func (a *App) collectMarketplaces(agents app.AgentContext) map[string]app.Market
 	return merged
 }
 
-func (a *App) collectSandboxHosts(agents app.AgentContext) []string {
-	sources := [][]string{a.opts.SandboxAllowedHosts}
+func (a *App) collectSandboxDomains(agents app.AgentContext) []string {
+	sources := [][]string{a.opts.SandboxAllowedDomains}
 	for _, ac := range agents.AgentConfigs {
-		sources = append(sources, ac.SandboxAllowedHosts)
+		sources = append(sources, ac.SandboxAllowedDomains)
 	}
 	return dedupeStrings(sources...)
 }
@@ -301,8 +301,12 @@ func (a *App) mergeSettings(outDir string, agents app.AgentContext) (string, err
 	network["allowAllUnixSockets"] = true
 	network["allowLocalBinding"] = true
 
-	allowedHostsRaw, _ := network["allowedHosts"].([]any)
-	network["allowedHosts"] = mergeStringsIntoAnySlice(allowedHostsRaw, a.collectSandboxHosts(agents))
+	allowedDomainsRaw, _ := network["allowedDomains"].([]any)
+	if legacy, ok := network["allowedHosts"].([]any); ok {
+		allowedDomainsRaw = append(allowedDomainsRaw, legacy...)
+		delete(network, "allowedHosts")
+	}
+	network["allowedDomains"] = mergeStringsIntoAnySlice(allowedDomainsRaw, a.collectSandboxDomains(agents))
 	sandbox["network"] = network
 
 	filesystem, _ := sandbox["filesystem"].(map[string]any)

--- a/agents/claude/claude_test.go
+++ b/agents/claude/claude_test.go
@@ -3,6 +3,7 @@ package claude
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"slices"
 	"testing"
 
@@ -14,9 +15,9 @@ func testOptions() Options {
 		Marketplaces: map[string]app.Marketplace{
 			"test-marketplace": {Repo: "example/test-marketplace"},
 		},
-		AlwaysOnPlugins:     []string{"always-on@test-marketplace"},
-		SandboxAllowedHosts: []string{"default.example.com"},
-		SandboxAllowWrite:   []string{"~/default-path"},
+		AlwaysOnPlugins:       []string{"always-on@test-marketplace"},
+		SandboxAllowedDomains: []string{"default.example.com"},
+		SandboxAllowWrite:     []string{"~/default-path"},
 	}
 }
 
@@ -87,27 +88,27 @@ func TestCollectPluginsAggregatesAllConfigs(t *testing.T) {
 	}
 }
 
-func TestCollectSandboxHostsAggregates(t *testing.T) {
+func TestCollectSandboxDomainsAggregates(t *testing.T) {
 	opts := testOptions()
 	a := New(opts)
 	ctx := app.AgentContext{
 		AgentConfigs: []app.AgentConfig{
-			{SandboxAllowedHosts: []string{"crates.io"}},
-			{SandboxAllowedHosts: []string{"registry.npmjs.org"}},
+			{SandboxAllowedDomains: []string{"crates.io"}},
+			{SandboxAllowedDomains: []string{"registry.npmjs.org"}},
 		},
 	}
 
-	hosts := a.collectSandboxHosts(ctx)
+	domains := a.collectSandboxDomains(ctx)
 
-	if !contains(hosts, "crates.io") {
+	if !contains(domains, "crates.io") {
 		t.Error("expected crates.io to be present")
 	}
-	if !contains(hosts, "registry.npmjs.org") {
+	if !contains(domains, "registry.npmjs.org") {
 		t.Error("expected registry.npmjs.org to be present")
 	}
-	for _, h := range opts.SandboxAllowedHosts {
-		if !contains(hosts, h) {
-			t.Errorf("expected default host %q to be present", h)
+	for _, d := range opts.SandboxAllowedDomains {
+		if !contains(domains, d) {
+			t.Errorf("expected default domain %q to be present", d)
 		}
 	}
 }
@@ -214,6 +215,73 @@ func TestMergeSettingsMarketplaces(t *testing.T) {
 			t.Errorf("expected at least %d marketplaces, got %d", len(opts.Marketplaces), len(marketplaces))
 		}
 	})
+}
+
+func TestMergeSettingsWritesAllowedDomainsAndStripsLegacyKey(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	if err := os.MkdirAll(filepath.Join(fakeHome, ".claude"), 0o755); err != nil {
+		t.Fatalf("failed to create fake .claude dir: %v", err)
+	}
+	legacy := []byte(`{"sandbox":{"network":{"allowedHosts":["legacy.example.com"]}}}`)
+	if err := os.WriteFile(filepath.Join(fakeHome, ".claude", "settings.json"), legacy, 0o644); err != nil {
+		t.Fatalf("failed to write fake settings.json: %v", err)
+	}
+
+	opts := testOptions()
+	a := New(opts)
+	ctx := app.AgentContext{
+		AgentConfigs: []app.AgentConfig{
+			{SandboxAllowedDomains: []string{"crates.io"}},
+		},
+	}
+
+	outDir := t.TempDir()
+	result, err := a.mergeSettings(outDir, ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(result)
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+
+	sandbox, ok := settings["sandbox"].(map[string]any)
+	if !ok {
+		t.Fatal("expected sandbox to be a map")
+	}
+	network, ok := sandbox["network"].(map[string]any)
+	if !ok {
+		t.Fatal("expected sandbox.network to be a map")
+	}
+
+	if _, hasLegacy := network["allowedHosts"]; hasLegacy {
+		t.Error("legacy sandbox.network.allowedHosts key must be stripped on write")
+	}
+
+	domains, ok := network["allowedDomains"].([]any)
+	if !ok {
+		t.Fatal("expected sandbox.network.allowedDomains to be a slice")
+	}
+	for _, want := range []string{"crates.io", "default.example.com", "legacy.example.com"} {
+		found := false
+		for _, d := range domains {
+			if s, _ := d.(string); s == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected sandbox.network.allowedDomains to contain %q, got %v", want, domains)
+		}
+	}
 }
 
 func contains(slice []string, item string) bool {

--- a/app/context.go
+++ b/app/context.go
@@ -12,12 +12,12 @@ type Hook struct {
 }
 
 type AgentConfig struct {
-	Plugins             []string
-	Marketplaces        map[string]Marketplace
-	AllowedCommands     []string
-	SandboxAllowedHosts []string
-	SandboxAllowWrite   []string
-	Hooks               []Hook
+	Plugins               []string
+	Marketplaces          map[string]Marketplace
+	AllowedCommands       []string
+	SandboxAllowedDomains []string
+	SandboxAllowWrite     []string
+	Hooks                 []Hook
 }
 
 type AgentConfigProvider interface {

--- a/examples/eleonora/data/claude.go
+++ b/examples/eleonora/data/claude.go
@@ -25,7 +25,7 @@ func ClaudeOptions() claude.Options {
 			"command": "npx -y ccstatusline@latest",
 			"padding": 0,
 		},
-		SandboxAllowedHosts: []string{
+		SandboxAllowedDomains: []string{
 			"api.anthropic.com",
 			"code.claude.com",
 			"formulae.brew.sh",

--- a/languages/rust/rust.go
+++ b/languages/rust/rust.go
@@ -34,7 +34,7 @@ func (a *App) AgentConfig() app.AgentConfig {
 		Marketplaces: map[string]app.Marketplace{
 			"claude-plugins-official": {Repo: "anthropics/claude-plugins-official"},
 		},
-		SandboxAllowedHosts: []string{
+		SandboxAllowedDomains: []string{
 			"index.crates.io",
 			"static.crates.io",
 			"static.rust-lang.org",

--- a/languages/typescript/typescript.go
+++ b/languages/typescript/typescript.go
@@ -25,7 +25,7 @@ func (a *App) AgentConfig() app.AgentConfig {
 		AllowedCommands: []string{
 			"Bash(npm install)",
 		},
-		SandboxAllowedHosts: []string{
+		SandboxAllowedDomains: []string{
 			"registry.npmjs.org",
 		},
 		SandboxAllowWrite: []string{

--- a/programs/buildkite/buildkite.go
+++ b/programs/buildkite/buildkite.go
@@ -19,7 +19,7 @@ func (a *App) Name() string {
 
 func (a *App) AgentConfig() app.AgentConfig {
 	return app.AgentConfig{
-		SandboxAllowedHosts: []string{
+		SandboxAllowedDomains: []string{
 			"api.buildkite.com",
 			"buildkite.com",
 		},

--- a/programs/datadog/datadog.go
+++ b/programs/datadog/datadog.go
@@ -19,7 +19,7 @@ func (a *App) Name() string {
 
 func (a *App) AgentConfig() app.AgentConfig {
 	return app.AgentConfig{
-		SandboxAllowedHosts: []string{
+		SandboxAllowedDomains: []string{
 			"api.datadoghq.com",
 			"app.datadoghq.com",
 		},

--- a/programs/git/git.go
+++ b/programs/git/git.go
@@ -56,7 +56,7 @@ func (a *App) AgentConfig() app.AgentConfig {
 			"Bash(gh run list:*)",
 			"Bash(gh run watch:*)",
 		},
-		SandboxAllowedHosts: []string{
+		SandboxAllowedDomains: []string{
 			"api.github.com",
 			"docs.github.com",
 			"github.com",

--- a/programs/mise/mise.go
+++ b/programs/mise/mise.go
@@ -16,7 +16,7 @@ func (a *App) Name() string {
 
 func (a *App) AgentConfig() app.AgentConfig {
 	return app.AgentConfig{
-		SandboxAllowedHosts: []string{
+		SandboxAllowedDomains: []string{
 			"mise.jdx.dev",
 			"mise-versions.jdx.dev",
 			"hk.jdx.dev",


### PR DESCRIPTION
## Summary

- Claude Code's [sandbox docs](https://code.claude.com/docs/en/sandboxing#how-sandboxing-relates-to-permissions) and settings schema document the field as `sandbox.network.allowedDomains`, not `allowedHosts`. The misnamed key was silently ignored, so `gh` / `git fetch` / `curl` calls to `api.github.com` inside the sandbox always fell through to a `dangerouslyDisableSandbox` permission prompt.
- Renames the public Go API (`SandboxAllowedHosts` → `SandboxAllowedDomains`) and the JSON key written to `~/.claude/settings.json`.
- Adds a one-time migration in `mergeSettings`: any existing `network.allowedHosts` array has its values carried forward into `allowedDomains` and the dead key is deleted, so existing users (including any who added domains manually) get migrated cleanly on the next `shizuku sync`.

## Test plan

- [x] `task lint` and `task test` pass; new `TestMergeSettingsWritesAllowedDomainsAndStripsLegacyKey` regression-tests the migration with an isolated `$HOME`.
- [x] `task run -- diff` shows only the key-rename diff with all 19 entries (including manually-added datadog/buildkite/mise hosts) preserved.
- [x] Ran `task run -- sync` against my own `~/.claude/settings.json`; verified `allowedDomains` is set with all values and the legacy `allowedHosts` key is gone.
- [ ] In a fresh Claude Code session: run a sandboxed bash command that hits `api.github.com` (e.g. `gh api repos/cli/cli/releases/latest`) and confirm it executes silently without a permission prompt.
