### PR TITLE
feat(claude): add advisorModel option and Read tmp permission

### DIFF
--- a/agents/claude/claude.go
+++ b/agents/claude/claude.go
@@ -21,6 +21,7 @@ type Options struct {
 	SandboxAllowWrite     []string
 	AllowedCommands       []string
 	DefaultMode           string
+	AdvisorModel          string
 }
 
 type App struct {
@@ -260,6 +261,9 @@ func (a *App) mergeSettings(outDir string, agents app.AgentContext) (string, err
 
 	if a.opts.DefaultMode != "" {
 		settings["defaultMode"] = a.opts.DefaultMode
+	}
+	if a.opts.AdvisorModel != "" {
+		settings["advisorModel"] = a.opts.AdvisorModel
 	}
 	if a.opts.StatusLine != nil {
 		settings["statusLine"] = a.opts.StatusLine

--- a/examples/eleonora/data/claude.go
+++ b/examples/eleonora/data/claude.go
@@ -52,9 +52,11 @@ func ClaudeOptions() claude.Options {
 
 			"Bash(npx nx:*)",
 
+			"Read(//tmp/**)",
 			"Edit(//tmp/**)",
 			"Write(//tmp/**)",
 		},
-		DefaultMode: "plan",
+		DefaultMode:  "plan",
+		AdvisorModel: "opus",
 	}
 }


### PR DESCRIPTION
## Summary
- Add `AdvisorModel` field to `claude.Options` and merge it into `settings.json` as `advisorModel`
- Set `advisorModel: "opus"` in the default Eleonora config
- Add `Read(//tmp/**)` to allowed commands alongside the existing `Edit` and `Write` tmp permissions

## Test plan
- [ ] `task build` passes
- [ ] `task run -- diff -p` shows no unexpected changes (advisorModel already set to opus in live settings)
- [ ] `task run -- sync` applies cleanly
