### PR TITLE
feat(nvim): install tree-sitter-cli alongside neovim

### DIFF
--- a/programs/nvim/nvim.go
+++ b/programs/nvim/nvim.go
@@ -26,6 +26,10 @@ func (a *App) Install(ctx *app.Context) error {
 		return fmt.Errorf("failed to install neovim: %w", err)
 	}
 
+	if err := util.InstallBrewPackage("tree-sitter-cli", false); err != nil {
+		return fmt.Errorf("failed to install tree-sitter-cli: %w", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Install `tree-sitter-cli` (the standalone parser-generator binary) alongside `neovim` in the nvim app's `Install` method.
- Uses the existing idempotent `util.InstallBrewPackage` helper — no new utilities, no consumer wiring changes.
- Note: brew formula is `tree-sitter-cli`, not `tree-sitter` (the latter is the parsing library).

## Test plan
- [ ] `task build` succeeds
- [ ] `task lint` is clean
- [ ] `brew uninstall tree-sitter-cli` (if present), then `task run -- install` provisions it
- [ ] `tree-sitter --version` prints a version after install
- [ ] Re-running install logs `brew package already installed, skipping` for both `neovim` and `tree-sitter-cli`
