### PR TITLE
feat(acli): add atlassian-cli app to work profile

### DIFF
--- a/agents/claude/claude.go
+++ b/agents/claude/claude.go
@@ -13,18 +13,18 @@ import (
 var contents embed.FS
 
 type Options struct {
-	Marketplaces           map[string]app.Marketplace
-	AlwaysOnPlugins        []string
-	Env                    map[string]string
-	StatusLine             map[string]any
+	Marketplaces            map[string]app.Marketplace
+	AlwaysOnPlugins         []string
+	Env                     map[string]string
+	StatusLine              map[string]any
 	SandboxAllowedDomains   []string
 	SandboxAllowRead        []string
 	SandboxAllowWrite       []string
 	SandboxExcludedCommands []string
 	AllowedBashCommands     []string
 	AllowedToolPermissions  []string
-	DefaultMode            string
-	AdvisorModel           string
+	DefaultMode             string
+	AdvisorModel            string
 }
 
 type App struct {

--- a/app/context.go
+++ b/app/context.go
@@ -12,16 +12,16 @@ type Hook struct {
 }
 
 type AgentConfig struct {
-	Plugins                []string
-	Marketplaces           map[string]Marketplace
+	Plugins                 []string
+	Marketplaces            map[string]Marketplace
 	AllowedBashCommands     []string
 	AllowedToolPermissions  []string
 	SandboxAllowedDomains   []string
 	SandboxAllowRead        []string
 	SandboxAllowWrite       []string
 	SandboxExcludedCommands []string
-	Hooks                  []Hook
-	BashCommandPrefix      string
+	Hooks                   []Hook
+	BashCommandPrefix       string
 }
 
 type AgentConfigProvider interface {

--- a/examples/eleonora/main.go
+++ b/examples/eleonora/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/eleonorayaya/shizuku/languages/swift"
 	"github.com/eleonorayaya/shizuku/languages/typescript"
 	"github.com/eleonorayaya/shizuku/languages/zig"
+	"github.com/eleonorayaya/shizuku/programs/acli"
 	"github.com/eleonorayaya/shizuku/programs/aerospace"
 	"github.com/eleonorayaya/shizuku/programs/bat"
 	"github.com/eleonorayaya/shizuku/programs/buildkite"
@@ -90,6 +91,7 @@ func main() {
 				ruby.New(),
 			),
 			shizuku.WithPrograms(
+				acli.New(),
 				buildkite.New(),
 				datadog.New(),
 				k9s.New(),

--- a/programs/acli/acli.go
+++ b/programs/acli/acli.go
@@ -1,0 +1,57 @@
+package acli
+
+import (
+	"fmt"
+
+	"github.com/eleonorayaya/shizuku/app"
+	"github.com/eleonorayaya/shizuku/util"
+)
+
+type App struct{}
+
+func New() *App {
+	return &App{}
+}
+
+func (a *App) Name() string {
+	return "acli"
+}
+
+func (a *App) AgentConfig() app.AgentConfig {
+	return app.AgentConfig{
+		AllowedBashCommands: []string{
+			"acli --version:*",
+			"acli jira workitem search:*",
+			"acli jira workitem view:*",
+			"acli jira workitem attachment list:*",
+			"acli jira workitem comment list:*",
+			"acli jira workitem comment visibility:*",
+			"acli jira workitem link list:*",
+			"acli jira workitem link type:*",
+			"acli jira workitem watcher list:*",
+		},
+		SandboxAllowedDomains: []string{
+			"api.atlassian.com",
+			"as.atlassian.com",
+			"ingest.us.sentry.io",
+		},
+		SandboxAllowRead: []string{
+			"~/.config/acli",
+		},
+		SandboxAllowWrite: []string{
+			"~/.config/acli",
+		},
+	}
+}
+
+func (a *App) Install(ctx *app.Context) error {
+	if err := util.AddTap("atlassian/acli"); err != nil {
+		return fmt.Errorf("failed to add tap: %w", err)
+	}
+
+	if err := util.InstallBrewPackage("atlassian/acli/acli", false); err != nil {
+		return fmt.Errorf("failed to install acli: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- Add `programs/acli/` — installs Atlassian CLI via the `atlassian/acli` homebrew tap and declares an `AgentConfig` for the agentic tools.
- Allowlist readonly `acli jira workitem` subcommands (`search`, `view`, `attachment list`, `comment list`/`visibility`, `link list`/`type`, `watcher list`) plus `acli --version`.
- Grant sandbox read/write to `~/.config/acli` and network access to `api.atlassian.com`, `as.atlassian.com`, `ingest.us.sentry.io`.
- Register `acli.New()` in the **work** profile in `examples/eleonora/main.go`, so personal-profile syncs are unaffected.
- Separate `style:` commit picks up unrelated gofmt struct-field alignment drift in `agents/claude/claude.go` and `app/context.go`.

## Test plan
- [ ] `task build` — compiles cleanly.
- [ ] `task lint` — no further drift.
- [ ] `task run -- list` — `acli` appears under the work profile only.
- [ ] `task run -- diff` — preview shows the 9 readonly bash entries (with `rtk` prefix variants), `~/.config/acli` in `filesystem.allowRead`/`allowWrite`, and the three Atlassian/Sentry domains in `network.allowedHosts`.
- [ ] `task run -- install` — idempotent no-op on a machine with `atlassian/acli` already tapped.
- [ ] `task run -- sync` — applies the settings to `~/.claude/settings.json`.
