### PR TITLE
feat(nvim): enable ui2, fix LspAttach event casing

### DIFF
--- a/programs/nvim/contents/after/plugin/ui.lua
+++ b/programs/nvim/contents/after/plugin/ui.lua
@@ -1,3 +1,5 @@
+require("vim._core.ui2").enable()
+
 vim.opt.laststatus = 3
 vim.opt.pumblend = 15
 vim.opt.winblend = 0

--- a/programs/nvim/contents/lua/plugins/lsp-lines.lua
+++ b/programs/nvim/contents/lua/plugins/lsp-lines.lua
@@ -1,7 +1,7 @@
 return {
   {
     "https://git.sr.ht/~whynothugo/lsp_lines.nvim",
-    event = "LSPAttach",
+    event = "LspAttach",
     config = function()
       local lsp_lines = require("lsp_lines")
       local original_hide = lsp_lines.hide

--- a/programs/nvim/contents/lua/plugins/none-ls.lua
+++ b/programs/nvim/contents/lua/plugins/none-ls.lua
@@ -166,7 +166,7 @@ end
 return {
   {
     "nvimtools/none-ls.nvim",
-    event = "LSPAttach",
+    event = "LspAttach",
     dependencies = {
       "nvim-lua/plenary.nvim",
       "romus204/tree-sitter-manager.nvim",


### PR DESCRIPTION
## Summary
- Enable Neovim 0.12 experimental `ui2` UI redesign (`require("vim._core.ui2").enable()` in `after/plugin/ui.lua`)
- Fix `LSPAttach` → `LspAttach` event casing in `lsp-lines.lua` and `none-ls.lua` — the wrong casing prevented both plugins from ever loading on LSP attach

## Test plan
- [ ] Open Neovim and confirm no startup errors
- [ ] Open a Go file and confirm inline LSP diagnostic lines render (lsp-lines working)
- [ ] Confirm null-ls code actions are available in Go files (none-ls working)
