### PR TITLE
feat(gh-dash): add gh-dash app to default profile

### DIFF
--- a/examples/eleonora/main.go
+++ b/examples/eleonora/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/eleonorayaya/shizuku/programs/desktoppr"
 	"github.com/eleonorayaya/shizuku/programs/fastfetch"
 	"github.com/eleonorayaya/shizuku/programs/git"
+	ghdash "github.com/eleonorayaya/shizuku/programs/gh-dash"
 	"github.com/eleonorayaya/shizuku/programs/glow"
 	"github.com/eleonorayaya/shizuku/programs/jankyborders"
 	"github.com/eleonorayaya/shizuku/programs/k9s"
@@ -89,6 +90,7 @@ func main() {
 			bat.New(),
 			desktoppr.New(),
 			fastfetch.New(),
+			ghdash.New(),
 			git.New(),
 			glow.New(),
 			jankyborders.New(),

--- a/programs/gh-dash/ghdash.go
+++ b/programs/gh-dash/ghdash.go
@@ -1,0 +1,30 @@
+package ghdash
+
+import (
+	"fmt"
+
+	"github.com/eleonorayaya/shizuku/app"
+	"github.com/eleonorayaya/shizuku/util"
+)
+
+type App struct{}
+
+func New() *App {
+	return &App{}
+}
+
+func (a *App) Name() string {
+	return "gh-dash"
+}
+
+func (a *App) Install(ctx *app.Context) error {
+	if err := util.AddTap("dlvhdr/gh-dash"); err != nil {
+		return fmt.Errorf("failed to add tap: %w", err)
+	}
+
+	if err := util.InstallBrewPackage("dlvhdr/gh-dash/gh-dash", false); err != nil {
+		return fmt.Errorf("failed to install gh-dash: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary

- Adds `gh-dash` ([dlvhdr/gh-dash](https://github.com/dlvhdr/gh-dash)) as a shizuku program app
- Installs via `dlvhdr/gh-dash` Homebrew tap
- Registered in the default profile (available across all profiles)

## Test plan

- [x] `task build` compiles cleanly
- [x] `task run -- list` shows `gh-dash` in the program list

🤖 Generated with [Claude Code](https://claude.com/claude-code)