### PR TITLE
Expand acli + buildkite sandbox allowlists

### DIFF
--- a/programs/acli/acli.go
+++ b/programs/acli/acli.go
@@ -33,7 +33,9 @@ func (a *App) AgentConfig() app.AgentConfig {
 		SandboxAllowedDomains: []string{
 			"api.atlassian.com",
 			"as.atlassian.com",
+			"auth.atlassian.com",
 			"ingest.us.sentry.io",
+			"o55978.ingest.us.sentry.io",
 		},
 		SandboxAllowRead: []string{
 			"~/.config/acli",

--- a/programs/buildkite/buildkite.go
+++ b/programs/buildkite/buildkite.go
@@ -23,6 +23,12 @@ func (a *App) AgentConfig() app.AgentConfig {
 			"api.buildkite.com",
 			"buildkite.com",
 		},
+		SandboxAllowRead: []string{
+			"~/.config/bk.yaml",
+		},
+		SandboxAllowWrite: []string{
+			"~/.config/bk.yaml",
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary
- **acli**: add `auth.atlassian.com` and `o55978.ingest.us.sentry.io` to `SandboxAllowedDomains` so the sandbox permits Atlassian auth and the org-specific Sentry ingest endpoint.
- **buildkite**: grant the `bk` CLI sandbox read/write to `~/.config/bk.yaml`, where it stores its selected org and API token — without it the sandboxed CLI can't read its credentials.

## Test plan
- [ ] `task run -- sync` regenerates `~/.claude/settings.json` with the new sandbox hosts and filesystem paths
- [ ] After restarting the Claude Code session, acli commands reach Atlassian auth / Sentry ingest inside the sandbox
- [ ] After restarting the session, `bk` reads its token from `~/.config/bk.yaml` inside the sandbox
