### PR TITLE
feat(claude): block aws cli via permissions.deny

### DIFF
--- a/.claude/skills/claude-config/Skill.md
+++ b/.claude/skills/claude-config/Skill.md
@@ -19,6 +19,7 @@ The claude app reads the existing `~/.claude/settings.json`, additively merges m
 |-------|------|----------|----------|
 | `enabledPlugins` | `map[string]any` | Set key to `true` | `desiredPlugins` |
 | `permissions.allow` | `[]any` | Append if not present | `desiredAllowedCommands` |
+| `permissions.deny` | `[]any` | Append if not present | `DeniedBashCommands` |
 | `env` | `map[string]any` | Set key to value | `desiredEnv` |
 
 Unmanaged fields (e.g. `plansDirectory`, `promptSuggestionEnabled`) pass through untouched.
@@ -45,6 +46,22 @@ var desiredAllowedCommands = []string{
     "Bash(docker:*)",  // add here
 }
 ```
+
+## Blocking a Command
+
+To **block** a bash command (so Claude Code refuses to run it), add the raw command to the
+`DeniedBashCommands` slice in the consumer data (`examples/eleonora/data/claude.go`). Each entry
+is wrapped as `Bash(<entry>)` and merged into `permissions.deny`, which takes precedence over
+`permissions.allow`.
+
+```go
+DeniedBashCommands: []string{
+    "aws",    // blocks bare `aws`
+    "aws:*",  // blocks `aws <anything>`
+},
+```
+
+Include both the bare command and the `:*` form to cover invocations with and without arguments.
 
 ## Adding a Plugin
 

--- a/agents/claude/claude.go
+++ b/agents/claude/claude.go
@@ -23,6 +23,7 @@ type Options struct {
 	SandboxExcludedCommands []string
 	AllowedBashCommands     []string
 	AllowedToolPermissions  []string
+	DeniedBashCommands      []string
 	DefaultMode             string
 	AdvisorModel            string
 }
@@ -145,6 +146,15 @@ func (a *App) collectAllowedCommands(agents app.AgentContext) []string {
 		}
 	}
 	permissions = append(permissions, toolPerms...)
+	return permissions
+}
+
+func (a *App) collectDeniedCommands() []string {
+	cmds := dedupeStrings(a.opts.DeniedBashCommands)
+	permissions := make([]string, 0, len(cmds))
+	for _, cmd := range cmds {
+		permissions = append(permissions, "Bash("+cmd+")")
+	}
 	return permissions
 }
 
@@ -289,6 +299,9 @@ func (a *App) mergeSettings(outDir string, agents app.AgentContext) (string, err
 
 	allowRaw, _ := permissions["allow"].([]any)
 	permissions["allow"] = mergeStringsIntoAnySlice(allowRaw, a.collectAllowedCommands(agents))
+
+	denyRaw, _ := permissions["deny"].([]any)
+	permissions["deny"] = mergeStringsIntoAnySlice(denyRaw, a.collectDeniedCommands())
 	settings["permissions"] = permissions
 
 	if len(a.opts.Env) > 0 {

--- a/agents/claude/claude_test.go
+++ b/agents/claude/claude_test.go
@@ -521,3 +521,69 @@ func TestMergeSettingsHooksFromAgentConfig(t *testing.T) {
 		t.Errorf("expected rtk hook claude to be merged into settings, got %#v", hooks)
 	}
 }
+
+func TestCollectDeniedCommandsWrapsBashCommands(t *testing.T) {
+	opts := testOptions()
+	opts.DeniedBashCommands = []string{"aws", "aws:*"}
+	a := New(opts)
+
+	cmds := a.collectDeniedCommands()
+
+	for _, want := range []string{"Bash(aws)", "Bash(aws:*)"} {
+		if !contains(cmds, want) {
+			t.Errorf("expected %q to be present", want)
+		}
+	}
+}
+
+func TestCollectDeniedCommandsEmpty(t *testing.T) {
+	a := New(testOptions())
+
+	cmds := a.collectDeniedCommands()
+
+	if len(cmds) != 0 {
+		t.Errorf("expected no denied commands, got %d: %v", len(cmds), cmds)
+	}
+}
+
+func TestMergeSettingsWritesDeniedCommands(t *testing.T) {
+	opts := testOptions()
+	opts.DeniedBashCommands = []string{"aws", "aws:*"}
+	a := New(opts)
+
+	outDir := t.TempDir()
+	resultPath, err := a.mergeSettings(outDir, app.AgentContext{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(resultPath)
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+
+	permissions, ok := settings["permissions"].(map[string]any)
+	if !ok {
+		t.Fatal("expected permissions to be a map")
+	}
+	denyRaw, ok := permissions["deny"].([]any)
+	if !ok {
+		t.Fatal("expected permissions.deny to be a slice")
+	}
+	deny := make([]string, 0, len(denyRaw))
+	for _, entry := range denyRaw {
+		if s, ok := entry.(string); ok {
+			deny = append(deny, s)
+		}
+	}
+	for _, want := range []string{"Bash(aws)", "Bash(aws:*)"} {
+		if !contains(deny, want) {
+			t.Errorf("expected %q in permissions.deny, got %v", want, deny)
+		}
+	}
+}

--- a/examples/eleonora/data/claude.go
+++ b/examples/eleonora/data/claude.go
@@ -57,6 +57,10 @@ func ClaudeOptions() claude.Options {
 			"Edit(//tmp/**)",
 			"Write(//tmp/**)",
 		},
+		DeniedBashCommands: []string{
+			"aws",
+			"aws:*",
+		},
 		DefaultMode:  "plan",
 		AdvisorModel: "opus",
 	}


### PR DESCRIPTION
## Summary
- Add `permissions.deny` support to the shizuku `claude` app: new `DeniedBashCommands` option, a `collectDeniedCommands` helper that wraps each entry in `Bash(...)`, and a deny merge in `mergeSettings` mirroring the existing `allow` merge (additive + deduped via `mergeStringsIntoAnySlice`).
- Block the `aws` CLI in the eleonora profile by adding `DeniedBashCommands: ["aws", "aws:*"]` → `Bash(aws)` + `Bash(aws:*)` (both forms cover bare invocation and any args; `deny` takes precedence over `allow`).
- Document the new deny capability in the `claude-config` skill.

## Test plan
- [x] `task lint`, `task test` (claude package + full suite pass), `task build`
- [x] `task run -- diff` shows only `permissions.deny` gaining the two aws rules, nothing else
- [x] `task run -- sync` applied; `~/.claude/settings.json` contains the deny rules; re-running `diff` reports "No differences found" (idempotent)
