### PR TITLE
feat(git): install gh-stack extension and claude-code skill

### DIFF
--- a/programs/git/git.go
+++ b/programs/git/git.go
@@ -34,18 +34,31 @@ func (a *App) Name() string {
 	return "git"
 }
 
+var ghExtensions = []string{
+	"dlvhdr/gh-dash",
+	"github/gh-stack",
+}
+
 func (a *App) Install(ctx *app.Context) error {
 	if !util.BinaryExists("gh") {
-		return fmt.Errorf("gh not found in PATH; install the GitHub CLI before installing the gh-dash extension")
+		return fmt.Errorf("gh not found in PATH; install the GitHub CLI before installing gh extensions")
 	}
 
-	if ghExtensionInstalled("dlvhdr/gh-dash") {
-		return nil
+	for _, repo := range ghExtensions {
+		if ghExtensionInstalled(repo) {
+			continue
+		}
+
+		cmd := exec.Command("gh", "extension", "install", repo)
+		if output, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("failed to install %s extension: %s: %w", repo, string(output), err)
+		}
 	}
 
-	cmd := exec.Command("gh", "extension", "install", "dlvhdr/gh-dash")
+	// ponytail: gh skill install is idempotent and unguarded; add a check if it ever gets slow
+	cmd := exec.Command("gh", "skill", "install", "github/gh-stack", "--agent", "claude-code", "--scope", "user")
 	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to install gh-dash extension: %s: %w", string(output), err)
+		return fmt.Errorf("failed to install gh-stack skill: %s: %w", string(output), err)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- Add `github/gh-stack` to the git app's `gh` extension install list (alongside `gh-dash`)
- Install the related Claude Code skill: `gh skill install github/gh-stack --agent claude-code --scope user`

## Test plan
- [ ] `task run -- install` installs both gh extensions and the gh-stack skill
- [ ] Re-running install is a no-op for already-installed extensions
